### PR TITLE
Fix anonymous user cannot read public knowledge & `Users#ANY` permission cannot be added to knowledge

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/internal/rest/ExceptionMappers.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/rest/ExceptionMappers.java
@@ -27,7 +27,7 @@ import com.github.llamara.ai.internal.internal.chat.ChatModelNotFoundException;
 import com.github.llamara.ai.internal.internal.knowledge.EmptyFileException;
 import com.github.llamara.ai.internal.internal.knowledge.KnowledgeNotFoundException;
 import com.github.llamara.ai.internal.internal.security.session.SessionNotFoundException;
-import com.github.llamara.ai.internal.internal.security.user.UserNotLoggedInException;
+import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
 import io.quarkus.logging.Log;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
@@ -62,7 +62,7 @@ class ExceptionMappers {
     }
 
     @ServerExceptionMapper
-    Response handleUserNotLoggedInException(UserNotLoggedInException e) {
+    Response handleUserNotLoggedInException(UserNotRegisteredException e) {
         return Response.status(Response.Status.UNAUTHORIZED.getStatusCode(), "User not logged in.")
                 .build();
     }

--- a/src/main/java/com/github/llamara/ai/internal/internal/rest/KnowledgeResource.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/rest/KnowledgeResource.java
@@ -173,11 +173,11 @@ class KnowledgeResource {
     @RolesAllowed({Roles.ADMIN, Roles.USER})
     @Blocking
     @PUT
-    @Path("/add")
+    @Path("/add/file")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "addKnowledge",
+            operationId = "addFileSource",
             summary = "Add a set of files to the knowledge.",
             description = "If a file is empty, it is skipped.")
     @APIResponse(
@@ -219,12 +219,12 @@ class KnowledgeResource {
     @RolesAllowed({Roles.ADMIN, Roles.USER})
     @Blocking
     @PUT
-    @Path("/update/{id}")
+    @Path("/update/{id}/file")
     @ResponseStatus(200)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(
-            operationId = "updateKnowledge",
-            summary = "Update a single knowledge identified by it ID.",
+            operationId = "updateFileSource",
+            summary = "Update the file source of a single knowledge identified by it ID.",
             description = "If the file is empty, it is skipped.")
     @APIResponse(responseCode = "200", description = "OK.")
     @APIResponse(responseCode = "400", description = "File upload is invalid.")

--- a/src/main/java/com/github/llamara/ai/internal/internal/rest/UserResource.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/rest/UserResource.java
@@ -71,7 +71,7 @@ public class UserResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = UserInfoDTO.class)))
     public UserInfoDTO login() {
-        userSessionManager.login();
+        userSessionManager.register();
         return new UserInfoDTO(identity, userInfo);
     }
 

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserAwareKnowledgeRepository.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserAwareKnowledgeRepository.java
@@ -22,8 +22,6 @@ package com.github.llamara.ai.internal.internal.security.knowledge;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import com.github.llamara.ai.internal.internal.security.Users;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
@@ -33,6 +31,7 @@ import com.github.llamara.ai.internal.internal.knowledge.Knowledge;
 import com.github.llamara.ai.internal.internal.knowledge.KnowledgeRepository;
 import com.github.llamara.ai.internal.internal.security.Permission;
 import com.github.llamara.ai.internal.internal.security.Roles;
+import com.github.llamara.ai.internal.internal.security.Users;
 import io.quarkus.security.identity.SecurityIdentity;
 
 /**
@@ -56,8 +55,8 @@ public class UserAwareKnowledgeRepository extends KnowledgeRepository {
      * Check if the current user has at least read permission for the given knowledge entry.
      *
      * <ul>
-     *     <li>Owners always have read/write permission.
-     *     <li>Anonymous users only have access if {@link Users#ANY} has read access.</li>
+     *   <li>Owners always have read/write permission.
+     *   <li>Anonymous users only have access if {@link Users#ANY} has read access.
      * </ul>
      *
      * @param knowledge
@@ -74,8 +73,8 @@ public class UserAwareKnowledgeRepository extends KnowledgeRepository {
     }
 
     /**
-     * List all knowledge entries that the user has at least read permission for.
-     * Admins have access to everything.
+     * List all knowledge entries that the user has at least read permission for. Admins have access
+     * to everything.
      *
      * @return
      */
@@ -87,8 +86,8 @@ public class UserAwareKnowledgeRepository extends KnowledgeRepository {
     }
 
     /**
-     * Find a knowledge entry by its ID and check if the user has at least read permission.
-     * Admins have access to everything.
+     * Find a knowledge entry by its ID and check if the user has at least read permission. Admins
+     * have access to everything.
      *
      * @param id
      * @return the entity found, or <code>null</code> if not found

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserAwareKnowledgeRepository.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserAwareKnowledgeRepository.java
@@ -22,6 +22,8 @@ package com.github.llamara.ai.internal.internal.security.knowledge;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import com.github.llamara.ai.internal.internal.security.Users;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
@@ -51,26 +53,42 @@ public class UserAwareKnowledgeRepository extends KnowledgeRepository {
     }
 
     /**
-     * List all knowledge entries that the user has at least read permission for. Admins can see
-     * everything.
+     * Check if the current user has at least read permission for the given knowledge entry.
+     *
+     * <ul>
+     *     <li>Owners always have read/write permission.
+     *     <li>Anonymous users only have access if {@link Users#ANY} has read access.</li>
+     * </ul>
+     *
+     * @param knowledge
+     * @return
+     */
+    private boolean hasReadPermission(Knowledge knowledge) {
+        if (identity.hasRole(Roles.ADMIN)) {
+            return true;
+        }
+        if (!identity.isAnonymous()) {
+            return knowledge.getPermission(identity.getPrincipal().getName()) != Permission.NONE;
+        }
+        return knowledge.getPermission(Users.ANY) != Permission.NONE;
+    }
+
+    /**
+     * List all knowledge entries that the user has at least read permission for.
+     * Admins have access to everything.
      *
      * @return
      */
     @Override
     public List<Knowledge> listAll() {
         return super.listAll().stream() // TODO: Filter in DB query
-                .filter(
-                        knowledge ->
-                                identity.hasRole(Roles.ADMIN)
-                                        || knowledge.getPermission(
-                                                        identity.getPrincipal().getName())
-                                                != Permission.NONE)
+                .filter(this::hasReadPermission)
                 .toList();
     }
 
     /**
-     * Find a knowledge entry by its ID and check if the user has at least read permission. Admins
-     * can see everything.
+     * Find a knowledge entry by its ID and check if the user has at least read permission.
+     * Admins have access to everything.
      *
      * @param id
      * @return the entity found, or <code>null</code> if not found
@@ -81,14 +99,7 @@ public class UserAwareKnowledgeRepository extends KnowledgeRepository {
         if (knowledge == null) {
             return null;
         }
-        if (identity.hasRole(Roles.ADMIN)) {
-            return knowledge;
-        }
-        if (!identity.hasRole(Roles.ADMIN)
-                && knowledge.getPermission(identity.getPrincipal().getName()) == Permission.NONE) {
-            return null;
-        }
-        return knowledge;
+        return hasReadPermission(knowledge) ? knowledge : null;
     }
 
     /**

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
@@ -69,13 +69,13 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
 
     @Override
     public Collection<Knowledge> getAllKnowledge() {
-        userSessionManager.enforceLoggedIn();
+        userSessionManager.enforceRegistered();
         return userAwareRepository.listAll();
     }
 
     @Override
     public Knowledge getKnowledge(UUID id) throws KnowledgeNotFoundException {
-        userSessionManager.enforceLoggedIn();
+        userSessionManager.enforceRegistered();
         Knowledge knowledge = userAwareRepository.findById(id);
         if (knowledge == null) {
             throw new KnowledgeNotFoundException(id);
@@ -92,7 +92,7 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
      */
     private void enforceKnowledgeEditable(UUID id)
             throws KnowledgeNotFoundException, ForbiddenException {
-        userSessionManager.enforceLoggedIn();
+        userSessionManager.enforceRegistered();
         if (identity.hasRole(Roles.ADMIN)) {
             return;
         }
@@ -115,7 +115,7 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
     @Override
     public UUID addSource(Path file, String fileName, String contentType)
             throws IOException, UnexpectedFileStorageFailureException {
-        userSessionManager.enforceLoggedIn();
+        userSessionManager.enforceRegistered();
 
         String checksum = Utils.generateChecksum(file);
         Optional<Knowledge> existingKnowledge = userAwareRepository.existsChecksum(checksum);
@@ -169,7 +169,7 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
     @Override
     public NamedFileContainer getFile(UUID id)
             throws KnowledgeNotFoundException, UnexpectedFileStorageFailureException {
-        userSessionManager.enforceLoggedIn();
+        userSessionManager.enforceRegistered();
         Knowledge knowledge = getKnowledge(id);
         return delegate.getFile(knowledge.getId());
     }

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
@@ -87,12 +87,14 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
      * Check whether the given knowledge is editable for the current user.
      *
      * <ul>
-     *     <li>Admins always have read/write permission.</li>
+     *   <li>Admins always have read/write permission.
      * </ul>
      *
      * @param id the ID of the knowledge to check
-     * @throws KnowledgeNotFoundException if the knowledge with the given ID does not exist or the user has no access to it
-     * @throws ForbiddenException if the user is not allowed to edit the knowledge, but has read access
+     * @throws KnowledgeNotFoundException if the knowledge with the given ID does not exist or the
+     *     user has no access to it
+     * @throws ForbiddenException if the user is not allowed to edit the knowledge, but has read
+     *     access
      */
     private void enforceKnowledgeEditable(UUID id)
             throws KnowledgeNotFoundException, ForbiddenException {

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
@@ -86,9 +86,13 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
     /**
      * Check whether the given knowledge is editable for the current user.
      *
+     * <ul>
+     *     <li>Admins always have read/write permission.</li>
+     * </ul>
+     *
      * @param id the ID of the knowledge to check
-     * @throws KnowledgeNotFoundException if the knowledge with the given ID does not exist
-     * @throws ForbiddenException if the user is not allowed to edit the knowledge
+     * @throws KnowledgeNotFoundException if the knowledge with the given ID does not exist or the user has no access to it
+     * @throws ForbiddenException if the user is not allowed to edit the knowledge, but has read access
      */
     private void enforceKnowledgeEditable(UUID id)
             throws KnowledgeNotFoundException, ForbiddenException {

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/session/AnonymousUserSessionManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/session/AnonymousUserSessionManagerImpl.java
@@ -36,7 +36,7 @@ import jakarta.inject.Inject;
 
 import com.github.llamara.ai.internal.config.UserSecurityConfig;
 import com.github.llamara.ai.internal.internal.chat.history.ChatMessageRecord;
-import com.github.llamara.ai.internal.internal.security.user.UserNotLoggedInException;
+import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.Shutdown;
@@ -86,13 +86,13 @@ public class AnonymousUserSessionManagerImpl implements UserSessionManager {
     }
 
     @Override
-    public boolean login() {
-        return false;
+    public boolean register() {
+        return true;
     }
 
     @Override
-    public void enforceLoggedIn() throws UserNotLoggedInException {
-        throw new UserNotLoggedInException();
+    public void enforceRegistered() throws UserNotRegisteredException {
+        // do nothing
     }
 
     @Override

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImpl.java
@@ -87,9 +87,7 @@ public class AuthenticatedUserSessionManagerImpl implements UserSessionManager {
                             user.getUsername()));
             created = true;
         }
-        Log.debug(
-                String.format(
-                        "User '%s' found in database, updating user.", user.getUsername()));
+        Log.debug(String.format("User '%s' found in database, updating user.", user.getUsername()));
         user.setDisplayName(userInfo.getName());
         userRepository.persist(user);
         QuarkusTransaction.commit();

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImpl.java
@@ -30,8 +30,7 @@ import jakarta.transaction.Transactional;
 import com.github.llamara.ai.internal.internal.chat.history.ChatHistoryStore;
 import com.github.llamara.ai.internal.internal.chat.history.ChatMessageRecord;
 import com.github.llamara.ai.internal.internal.security.user.User;
-import com.github.llamara.ai.internal.internal.security.user.UserNotFoundException;
-import com.github.llamara.ai.internal.internal.security.user.UserNotLoggedInException;
+import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
 import com.github.llamara.ai.internal.internal.security.user.UserRepository;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkus.logging.Log;
@@ -76,35 +75,32 @@ public class AuthenticatedUserSessionManagerImpl implements UserSessionManager {
     }
 
     @Override
-    public boolean login() {
+    public boolean register() {
+        boolean created = false;
         QuarkusTransaction.begin();
-        boolean updated = true;
-        User user;
-        try {
-            user = userRepository.findByUsername(identity.getPrincipal().getName());
-            Log.debug(
-                    String.format(
-                            "User '%s' found in database, updating user.", user.getUsername()));
-        } catch (UserNotFoundException e) {
-            updated = false;
+        User user = userRepository.findByUsername(identity.getPrincipal().getName());
+        if (user == null) {
             user = new User(identity.getPrincipal().getName());
             Log.debug(
                     String.format(
                             "User '%s' not found in database, creating new user.",
                             user.getUsername()));
+            created = true;
         }
+        Log.debug(
+                String.format(
+                        "User '%s' found in database, updating user.", user.getUsername()));
         user.setDisplayName(userInfo.getName());
         userRepository.persist(user);
         QuarkusTransaction.commit();
-        return updated;
+        return created;
     }
 
     @Override
-    public void enforceLoggedIn() {
-        try {
-            userRepository.findByUsername(identity.getPrincipal().getName());
-        } catch (UserNotFoundException e) {
-            throw new UserNotLoggedInException(identity.getPrincipal().getName());
+    public void enforceRegistered() {
+        User user = userRepository.findByUsername(identity.getPrincipal().getName());
+        if (user == null) {
+            throw new UserNotRegisteredException(identity.getPrincipal().getName());
         }
     }
 
@@ -132,11 +128,11 @@ public class AuthenticatedUserSessionManagerImpl implements UserSessionManager {
 
     private User getUser() {
         String username = identity.getPrincipal().getName();
-        try {
-            return userRepository.findByUsername(username);
-        } catch (UserNotFoundException e) {
-            throw new UserNotLoggedInException(username);
+        User user = userRepository.findByUsername(username);
+        if (user == null) {
+            throw new UserNotRegisteredException(username);
         }
+        return user;
     }
 
     /**

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/session/UserSessionManager.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/session/UserSessionManager.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.github.llamara.ai.internal.internal.chat.history.ChatMessageRecord;
-import com.github.llamara.ai.internal.internal.security.user.UserNotLoggedInException;
+import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -33,19 +33,24 @@ import io.smallrye.mutiny.Uni;
  * Authentication itself is handled by the OIDC provider, e.g. Keycloak.
  *
  * <p>Users must log in before any other operation can be performed. If the user is not logged in
- * and tries to perform an operation, the operation can fail with {@link UserNotLoggedInException}.
+ * and tries to perform an operation, the operation can fail with {@link UserNotRegisteredException}.
  *
  * @author Florian Hotze - Initial contribution
  */
 public interface UserSessionManager {
     /**
-     * Logs the user in, i.e. creates or updates the user in the database.
+     * Registers the user in, i.e. creates or updates the user in the database.
      *
-     * @return {@code true} if the user was updated, {@code false} if the user was created
+     * @return {@code true} if the user was created, {@code false} if the user was updated
      */
-    boolean login();
+    boolean register();
 
-    void enforceLoggedIn() throws UserNotLoggedInException;
+    /**
+     * Enforces that the user is registered.
+     * If the user is not registered, a {@link UserNotRegisteredException} is thrown.
+     * @throws UserNotRegisteredException
+     */
+    void enforceRegistered() throws UserNotRegisteredException;
 
     /** Deletes the current user and all his data. This includes removing all sessions. */
     void delete();

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/session/UserSessionManager.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/session/UserSessionManager.java
@@ -33,7 +33,8 @@ import io.smallrye.mutiny.Uni;
  * Authentication itself is handled by the OIDC provider, e.g. Keycloak.
  *
  * <p>Users must log in before any other operation can be performed. If the user is not logged in
- * and tries to perform an operation, the operation can fail with {@link UserNotRegisteredException}.
+ * and tries to perform an operation, the operation can fail with {@link
+ * UserNotRegisteredException}.
  *
  * @author Florian Hotze - Initial contribution
  */
@@ -46,8 +47,9 @@ public interface UserSessionManager {
     boolean register();
 
     /**
-     * Enforces that the user is registered.
-     * If the user is not registered, a {@link UserNotRegisteredException} is thrown.
+     * Enforces that the user is registered. If the user is not registered, a {@link
+     * UserNotRegisteredException} is thrown.
+     *
      * @throws UserNotRegisteredException
      */
     void enforceRegistered() throws UserNotRegisteredException;

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserNotRegisteredException.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserNotRegisteredException.java
@@ -20,16 +20,12 @@
 package com.github.llamara.ai.internal.internal.security.user;
 
 /**
- * Exception signaling that the user is not logged in.
+ * Exception signaling that the user is not registered.
  *
  * @author Florian Hotze - Initial contribution
  */
-public class UserNotLoggedInException extends RuntimeException {
-    public UserNotLoggedInException() {
-        super("User is not logged in.");
-    }
-
-    public UserNotLoggedInException(String username) {
-        super(String.format("User '%s' is not logged in.", username));
+public class UserNotRegisteredException extends RuntimeException {
+    public UserNotRegisteredException(String username) {
+        super(String.format("User '%s' is not registered.", username));
     }
 }

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserRepository.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserRepository.java
@@ -33,6 +33,14 @@ import jakarta.transaction.Transactional;
  */
 @ApplicationScoped
 public class UserRepository implements PanacheRepository<User> {
+    @Startup
+    @Transactional
+    void init() {
+        if (findByUsername(Users.ANY_USERNAME) == null) {
+            persist(Users.ANY);
+        }
+    }
+
     /**
      * Find a user by its username.
      *

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserRepository.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserRepository.java
@@ -19,12 +19,12 @@
  */
 package com.github.llamara.ai.internal.internal.security.user;
 
-import com.github.llamara.ai.internal.internal.security.Users;
-import io.quarkus.runtime.Startup;
 import jakarta.enterprise.context.ApplicationScoped;
-
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.transaction.Transactional;
+
+import com.github.llamara.ai.internal.internal.security.Users;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.runtime.Startup;
 
 /**
  * Hibernate ORM {@link PanacheRepository} for {@link User}.

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserRepository.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserRepository.java
@@ -19,9 +19,12 @@
  */
 package com.github.llamara.ai.internal.internal.security.user;
 
+import com.github.llamara.ai.internal.internal.security.Users;
+import io.quarkus.runtime.Startup;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.transaction.Transactional;
 
 /**
  * Hibernate ORM {@link PanacheRepository} for {@link User}.
@@ -34,14 +37,9 @@ public class UserRepository implements PanacheRepository<User> {
      * Find a user by its username.
      *
      * @param username the username of the user
-     * @return the user
-     * @throws UserNotFoundException if no user with the given username was found
+     * @return the entity found, or <code>null</code> if not found
      */
-    public User findByUsername(String username) throws UserNotFoundException {
-        User user = find("username", username).firstResult();
-        if (user == null) {
-            throw new UserNotFoundException(username);
-        }
-        return user;
+    public User findByUsername(String username) {
+        return find("username", username).firstResult();
     }
 }

--- a/src/test/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeManagerImplTest.java
@@ -22,6 +22,8 @@ package com.github.llamara.ai.internal.internal.knowledge;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.UUID;
+
+import com.github.llamara.ai.internal.internal.security.Users;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
@@ -118,10 +120,13 @@ class KnowledgeManagerImplTest {
 
         assertEquals(0, knowledgeRepository.count());
 
+        if (userRepository.findByUsername(Users.ANY_USERNAME) == null) {
+            userRepository.persist(Users.ANY); // re-create Users#ANY after it has been deleted in destroy()
+        }
         userRepository.persist(OWNER_USER);
         userRepository.persist(OTHER_USER);
 
-        assertEquals(2, userRepository.count());
+        assertEquals(3, userRepository.count());
     }
 
     @Transactional

--- a/src/test/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeManagerImplTest.java
@@ -22,8 +22,6 @@ package com.github.llamara.ai.internal.internal.knowledge;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.UUID;
-
-import com.github.llamara.ai.internal.internal.security.Users;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
@@ -46,6 +44,7 @@ import com.github.llamara.ai.internal.internal.knowledge.embedding.EmbeddingStor
 import com.github.llamara.ai.internal.internal.knowledge.storage.FileStorage;
 import com.github.llamara.ai.internal.internal.knowledge.storage.UnexpectedFileStorageFailureException;
 import com.github.llamara.ai.internal.internal.security.Permission;
+import com.github.llamara.ai.internal.internal.security.Users;
 import com.github.llamara.ai.internal.internal.security.user.User;
 import com.github.llamara.ai.internal.internal.security.user.UserRepository;
 import dev.langchain4j.data.segment.TextSegment;
@@ -121,7 +120,8 @@ class KnowledgeManagerImplTest {
         assertEquals(0, knowledgeRepository.count());
 
         if (userRepository.findByUsername(Users.ANY_USERNAME) == null) {
-            userRepository.persist(Users.ANY); // re-create Users#ANY after it has been deleted in destroy()
+            userRepository.persist(
+                    Users.ANY); // re-create Users#ANY after it has been deleted in destroy()
         }
         userRepository.persist(OWNER_USER);
         userRepository.persist(OTHER_USER);

--- a/src/test/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeManagerImplTest.java
@@ -44,9 +44,8 @@ import com.github.llamara.ai.internal.internal.knowledge.embedding.EmbeddingStor
 import com.github.llamara.ai.internal.internal.knowledge.storage.FileStorage;
 import com.github.llamara.ai.internal.internal.knowledge.storage.UnexpectedFileStorageFailureException;
 import com.github.llamara.ai.internal.internal.security.Permission;
-import com.github.llamara.ai.internal.internal.security.Users;
+import com.github.llamara.ai.internal.internal.security.user.TestUserRepository;
 import com.github.llamara.ai.internal.internal.security.user.User;
-import com.github.llamara.ai.internal.internal.security.user.UserRepository;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.filter.Filter;
@@ -96,7 +95,7 @@ class KnowledgeManagerImplTest {
     private static final User OWNER_USER = new User("owner");
     private static final User OTHER_USER = new User("other");
 
-    @Inject UserRepository userRepository;
+    @Inject TestUserRepository userRepository;
 
     @InjectSpy KnowledgeRepository knowledgeRepository;
     @InjectMock DocumentIngestor documentIngestor;
@@ -119,12 +118,11 @@ class KnowledgeManagerImplTest {
 
         assertEquals(0, knowledgeRepository.count());
 
-        if (userRepository.findByUsername(Users.ANY_USERNAME) == null) {
-            userRepository.persist(
-                    Users.ANY); // re-create Users#ANY after it has been deleted in destroy()
-        }
+        userRepository.init();
         userRepository.persist(OWNER_USER);
         userRepository.persist(OTHER_USER);
+
+        clearAllInvocations();
 
         assertEquals(3, userRepository.count());
     }

--- a/src/test/java/com/github/llamara/ai/internal/internal/knowledge/TestKnowledgeManagerImpl.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/knowledge/TestKnowledgeManagerImpl.java
@@ -25,6 +25,10 @@ import com.github.llamara.ai.internal.internal.knowledge.storage.FileStorage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 
+/**
+ * Extends {@link KnowledgeManagerImpl} for modifying visibility of constructor and methods to
+ * access them in tests.
+ */
 public class TestKnowledgeManagerImpl extends KnowledgeManagerImpl {
     public TestKnowledgeManagerImpl(
             KnowledgeRepository repository,

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImplTest.java
@@ -48,9 +48,9 @@ import com.github.llamara.ai.internal.internal.knowledge.storage.FileStorage;
 import com.github.llamara.ai.internal.internal.knowledge.storage.UnexpectedFileStorageFailureException;
 import com.github.llamara.ai.internal.internal.security.Permission;
 import com.github.llamara.ai.internal.internal.security.session.UserSessionManager;
+import com.github.llamara.ai.internal.internal.security.user.TestUserRepository;
 import com.github.llamara.ai.internal.internal.security.user.User;
 import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
-import com.github.llamara.ai.internal.internal.security.user.UserRepository;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -81,7 +81,7 @@ class UserKnowledgeManagerImplTest {
     private static final User OWN_USER = new User("own");
     private static final User FOREGIN_USER = new User("foreign");
 
-    @Inject UserRepository userRepository;
+    @Inject TestUserRepository userRepository;
 
     // for TestKnowledgeManagerImpl
     @InjectSpy KnowledgeRepository knowledgeRepository;
@@ -116,12 +116,16 @@ class UserKnowledgeManagerImplTest {
                         userSessionManager,
                         identity);
 
+        userRepository.init();
         userRepository.persist(OWN_USER);
         userRepository.persist(FOREGIN_USER);
+
+        clearAllInvocations();
 
         doThrow(UserNotRegisteredException.class).when(userSessionManager).enforceRegistered();
 
         assertEquals(0, knowledgeRepository.count());
+        assertEquals(3, userRepository.count());
     }
 
     @Transactional

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImplTest.java
@@ -68,7 +68,8 @@ class UserKnowledgeManagerImplTest {
     private static final Path FILE = Path.of("src/test/resources/llamara.txt");
     private static final String FILE_NAME = "llamara.txt";
     private static final String FILE_MIME_TYPE = "text/plain";
-    private static final String FILE_CHECKSUM;
+    private static final String
+            FILE_CHECKSUM; // NOSONAR: ignore this unused static field as this is a test class
 
     static {
         try {

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImplTest.java
@@ -49,7 +49,7 @@ import com.github.llamara.ai.internal.internal.knowledge.storage.UnexpectedFileS
 import com.github.llamara.ai.internal.internal.security.Permission;
 import com.github.llamara.ai.internal.internal.security.session.UserSessionManager;
 import com.github.llamara.ai.internal.internal.security.user.User;
-import com.github.llamara.ai.internal.internal.security.user.UserNotLoggedInException;
+import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
 import com.github.llamara.ai.internal.internal.security.user.UserRepository;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
@@ -119,7 +119,7 @@ class UserKnowledgeManagerImplTest {
         userRepository.persist(OWN_USER);
         userRepository.persist(FOREGIN_USER);
 
-        doThrow(UserNotLoggedInException.class).when(userSessionManager).enforceLoggedIn();
+        doThrow(UserNotRegisteredException.class).when(userSessionManager).enforceRegistered();
 
         assertEquals(0, knowledgeRepository.count());
     }
@@ -158,7 +158,7 @@ class UserKnowledgeManagerImplTest {
                     knowledgeManager.addSource(FILE, FILE_NAME, FILE_MIME_TYPE, FOREGIN_USER);
             setupIdentity(OWN_USER);
 
-            doNothing().when(userSessionManager).enforceLoggedIn();
+            doNothing().when(userSessionManager).enforceRegistered();
             clearAllInvocations();
 
             assertEquals(2, knowledgeRepository.count());

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/session/AnonymousUserSessionManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/session/AnonymousUserSessionManagerImplTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.when;
 
 import com.github.llamara.ai.internal.config.UserSecurityConfig;
 import com.github.llamara.ai.internal.internal.chat.history.ChatMessageRecord;
-import com.github.llamara.ai.internal.internal.security.user.UserNotLoggedInException;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -91,13 +90,13 @@ class AnonymousUserSessionManagerImplTest {
     }
 
     @Test
-    void loginAlwaysClaimsToHaveCreatedUser() {
-        assertFalse(userSecurityManager.login());
+    void registerAlwaysClaimsToHaveCreatedUser() {
+        assertTrue(userSecurityManager.register());
     }
 
     @Test
-    void enforceUserLoggedInAlwaysThrowsException() {
-        assertThrows(UserNotLoggedInException.class, () -> userSecurityManager.enforceLoggedIn());
+    void enforceRegisteredDoesNotThrowException() {
+        assertDoesNotThrow(() -> userSecurityManager.enforceRegistered());
     }
 
     @Test

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
@@ -36,11 +36,10 @@ import static org.mockito.Mockito.*;
 
 import com.github.llamara.ai.internal.internal.chat.history.ChatHistoryStore;
 import com.github.llamara.ai.internal.internal.chat.history.ChatMessageRecord;
-import com.github.llamara.ai.internal.internal.security.Users;
+import com.github.llamara.ai.internal.internal.security.user.TestUserRepository;
 import com.github.llamara.ai.internal.internal.security.user.User;
 import com.github.llamara.ai.internal.internal.security.user.UserNotFoundException;
 import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
-import com.github.llamara.ai.internal.internal.security.user.UserRepository;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -67,7 +66,7 @@ class AuthenticatedUserSessionManagerImplTest {
     private static final List<ChatMessage> CHAT_HISTORY =
             List.of(new UserMessage("Hello, world!"), new AiMessage("Hi!"));
 
-    @InjectSpy UserRepository userRepository;
+    @InjectSpy TestUserRepository userRepository;
     @InjectSpy UserAwareSessionRepository userAwareSessionRepository;
     @InjectMock ChatMemoryStore chatMemoryStore;
     @InjectMock ChatHistoryStore chatHistoryStore;
@@ -91,10 +90,7 @@ class AuthenticatedUserSessionManagerImplTest {
 
         setupIdentity(OWN_USERNAME, OWN_DISPLAYNAME);
 
-        if (userRepository.findByUsername(Users.ANY_USERNAME) == null) {
-            userRepository.persist(
-                    Users.ANY); // re-create Users#ANY after it has been deleted in destroy()
-        }
+        userRepository.init();
 
         clearAllInvocations();
 

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
@@ -38,7 +38,7 @@ import com.github.llamara.ai.internal.internal.chat.history.ChatHistoryStore;
 import com.github.llamara.ai.internal.internal.chat.history.ChatMessageRecord;
 import com.github.llamara.ai.internal.internal.security.user.User;
 import com.github.llamara.ai.internal.internal.security.user.UserNotFoundException;
-import com.github.llamara.ai.internal.internal.security.user.UserNotLoggedInException;
+import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
 import com.github.llamara.ai.internal.internal.security.user.UserRepository;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -171,8 +171,8 @@ class AuthenticatedUserSessionManagerImplTest {
     }
 
     @Test
-    void loginCreatesUserIfNotExists() {
-        assertFalse(userSecurityManager.login());
+    void registerCreatesUserIfNotExists() {
+        assertTrue(userSecurityManager.register());
         verify(userRepository, times(1)).persist((User) any());
         User user = userRepository.listAll().getFirst();
         assertEquals(OWN_USERNAME, user.getUsername());
@@ -181,13 +181,13 @@ class AuthenticatedUserSessionManagerImplTest {
     }
 
     @Test
-    void enforceLoggedInThrowsIfNotLoggedIn() {
-        assertThrows(UserNotLoggedInException.class, () -> userSecurityManager.enforceLoggedIn());
+    void enforceRegisteredThrowsIfNotRegistered() {
+        assertThrows(UserNotRegisteredException.class, () -> userSecurityManager.enforceRegistered());
     }
 
     @Test
     void deleteThrowsAndDoesNothingIfNotExists() {
-        assertThrows(UserNotLoggedInException.class, () -> userSecurityManager.delete());
+        assertThrows(UserNotRegisteredException.class, () -> userSecurityManager.delete());
         verifyNothingDeleted();
     }
 
@@ -203,7 +203,7 @@ class AuthenticatedUserSessionManagerImplTest {
             String newDisplayName = "New Name";
             when(userInfo.getName()).thenReturn(newDisplayName);
 
-            assertTrue(userSecurityManager.login());
+            assertFalse(userSecurityManager.register());
             verify(userRepository, times(1)).persist((User) any());
             User user = userRepository.listAll().getFirst();
             assertEquals(OWN_USERNAME, user.getUsername());
@@ -271,8 +271,8 @@ class AuthenticatedUserSessionManagerImplTest {
         }
 
         @Test
-        void enforceLoggedInDoesNotThrowIfLoggedIn() {
-            assertDoesNotThrow(() -> userSecurityManager.enforceLoggedIn());
+        void enforceRegisteredDoesNotThrowIfLoggedIn() {
+            assertDoesNotThrow(() -> userSecurityManager.enforceRegistered());
         }
 
         @Test

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
@@ -229,7 +229,7 @@ class AuthenticatedUserSessionManagerImplTest {
         }
 
         @Test
-        void createSessionCreatesNewSession() throws UserNotFoundException {
+        void createSessionCreatesNewSession() {
             Session session = userSecurityManager.createSession();
             assertEquals(OWN_USERNAME, session.getUser().getUsername());
             assertEquals(1, userRepository.findByUsername(OWN_USERNAME).getSessions().size());

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/session/AuthenticatedUserSessionManagerImplTest.java
@@ -23,8 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
-import com.github.llamara.ai.internal.internal.security.Users;
 import jakarta.transaction.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -38,6 +36,7 @@ import static org.mockito.Mockito.*;
 
 import com.github.llamara.ai.internal.internal.chat.history.ChatHistoryStore;
 import com.github.llamara.ai.internal.internal.chat.history.ChatMessageRecord;
+import com.github.llamara.ai.internal.internal.security.Users;
 import com.github.llamara.ai.internal.internal.security.user.User;
 import com.github.llamara.ai.internal.internal.security.user.UserNotFoundException;
 import com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException;
@@ -93,7 +92,8 @@ class AuthenticatedUserSessionManagerImplTest {
         setupIdentity(OWN_USERNAME, OWN_DISPLAYNAME);
 
         if (userRepository.findByUsername(Users.ANY_USERNAME) == null) {
-            userRepository.persist(Users.ANY); // re-create Users#ANY after it has been deleted in destroy()
+            userRepository.persist(
+                    Users.ANY); // re-create Users#ANY after it has been deleted in destroy()
         }
 
         clearAllInvocations();
@@ -116,7 +116,8 @@ class AuthenticatedUserSessionManagerImplTest {
     }
 
     void clearAllInvocations() {
-        clearInvocations(userRepository, userAwareSessionRepository, chatMemoryStore, chatHistoryStore);
+        clearInvocations(
+                userRepository, userAwareSessionRepository, chatMemoryStore, chatHistoryStore);
     }
 
     /**
@@ -195,7 +196,8 @@ class AuthenticatedUserSessionManagerImplTest {
 
     @Test
     void enforceRegisteredThrowsIfNotRegistered() {
-        assertThrows(UserNotRegisteredException.class, () -> userSecurityManager.enforceRegistered());
+        assertThrows(
+                UserNotRegisteredException.class, () -> userSecurityManager.enforceRegistered());
     }
 
     @Test

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/user/TestUserRepository.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/user/TestUserRepository.java
@@ -1,0 +1,14 @@
+package com.github.llamara.ai.internal.internal.security.user;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Extends {@link UserRepository} for modifying visibility of constructor and methods to access them
+ * in tests.
+ */
+@ApplicationScoped
+public class TestUserRepository extends UserRepository {
+    public void init() {
+        super.init();
+    }
+}

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/user/TestUserRepository.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/user/TestUserRepository.java
@@ -1,13 +1,16 @@
 package com.github.llamara.ai.internal.internal.security.user;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
 
 /**
  * Extends {@link UserRepository} for modifying visibility of constructor and methods to access them
  * in tests.
  */
+@Typed(TestUserRepository.class)
 @ApplicationScoped
 public class TestUserRepository extends UserRepository {
+    @Override
     public void init() {
         super.init();
     }


### PR DESCRIPTION
- Refactors the `UserSessionManager` interface to improve method naming and make using it easier to understand.
- Refactors the `AnonymousUserSessionManager` to not throw an exception on `enforceRegistered` to allow anonymous users to read public knowledge.
- Makes sure that `Users#ANY` is in the DB to fix an exception being thrown when adding permission for it on any knowledge.