### PR TITLE
Improvements to retrieving user's knowledge & Enforce authentication for knowledge management

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/internal/knowledge/Knowledge.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/knowledge/Knowledge.java
@@ -112,7 +112,7 @@ public class Knowledge {
                     @JoinColumn(name = "knowledge_id")) // specify foreign key column that will link
     // elements to Knowledge entity
     @Column(name = "tag")
-    private Set<String> tags = new HashSet<>();
+    private final Set<String> tags = new HashSet<>();
 
     /** Constructor for JPA. */
     protected Knowledge() {}

--- a/src/main/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeRepository.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/knowledge/KnowledgeRepository.java
@@ -19,11 +19,14 @@
  */
 package com.github.llamara.ai.internal.internal.knowledge;
 
+import java.util.List;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 
 import com.github.llamara.ai.internal.internal.ingestion.IngestionStatus;
+import com.github.llamara.ai.internal.internal.security.Permission;
+import com.github.llamara.ai.internal.internal.security.Users;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 
 /**
@@ -33,6 +36,17 @@ import io.quarkus.hibernate.orm.panache.PanacheRepository;
  */
 @ApplicationScoped
 public class KnowledgeRepository implements PanacheRepository<Knowledge> {
+    /**
+     * List all knowledge entries that are public, i.e. shared with {@link Users#ANY}.
+     *
+     * @return public knowledge
+     */
+    public List<Knowledge> listAllPublicKnowledge() {
+        return listAll().stream() // TODO: Filter in DB query
+                .filter(k -> k.getPermission(Users.ANY) != Permission.NONE)
+                .toList();
+    }
+
     /**
      * Find knowledge by its ID.
      *

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserAwareKnowledgeRepository.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserAwareKnowledgeRepository.java
@@ -19,7 +19,6 @@
  */
 package com.github.llamara.ai.internal.internal.security.knowledge;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -70,19 +69,6 @@ public class UserAwareKnowledgeRepository extends KnowledgeRepository {
             return knowledge.getPermission(identity.getPrincipal().getName()) != Permission.NONE;
         }
         return knowledge.getPermission(Users.ANY) != Permission.NONE;
-    }
-
-    /**
-     * List all knowledge entries that the user has at least read permission for. Admins have access
-     * to everything.
-     *
-     * @return
-     */
-    @Override
-    public List<Knowledge> listAll() {
-        return super.listAll().stream() // TODO: Filter in DB query
-                .filter(this::hasReadPermission)
-                .toList();
     }
 
     /**

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManager.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManager.java
@@ -34,10 +34,13 @@ import io.quarkus.security.ForbiddenException;
  * io.quarkus.security.identity.SecurityIdentity}. Authentication itself is handled by the OIDC
  * provider, e.g. Keycloak.
  *
- * <p>Knowledge can only be managed by authenticated users.
+ * <p>Knowledge can only be managed by authenticated users, but anonymous users are allowed to get
+ * public knowledge. If a anonymous users tries to perform an operation that requires
+ * authentication, the operation must fail with {@link ForbiddenException}.
  *
- * <p>Users must log in before any other operation can be performed. If the user is not logged in
- * and tries to perform an operation, the operation can fail with {@link ForbiddenException}.
+ * <p>Users must register before any operation can be performed. If the user is not registered and
+ * tries to perform an operation, the operation can fail with {@link
+ * com.github.llamara.ai.internal.internal.security.user.UserNotRegisteredException}.
  *
  * @author Florian Hotze - Initial contribution
  */

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
@@ -83,6 +83,12 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
         return knowledge;
     }
 
+    private void enforceAuthenticated() {
+        if (identity.isAnonymous()) {
+            throw new ForbiddenException();
+        }
+    }
+
     /**
      * Check whether the given knowledge is editable for the current user.
      *
@@ -98,6 +104,7 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
      */
     private void enforceKnowledgeEditable(UUID id)
             throws KnowledgeNotFoundException, ForbiddenException {
+        enforceAuthenticated();
         userManager.enforceRegistered();
         if (identity.hasRole(Roles.ADMIN)) {
             return;
@@ -121,6 +128,7 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
     @Override
     public UUID addSource(Path file, String fileName, String contentType)
             throws IOException, UnexpectedFileStorageFailureException {
+        enforceAuthenticated();
         userManager.enforceRegistered();
 
         String checksum = Utils.generateChecksum(file);

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/knowledge/UserKnowledgeManagerImpl.java
@@ -22,7 +22,9 @@ package com.github.llamara.ai.internal.internal.security.knowledge;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
@@ -38,6 +40,7 @@ import com.github.llamara.ai.internal.internal.security.Permission;
 import com.github.llamara.ai.internal.internal.security.Roles;
 import com.github.llamara.ai.internal.internal.security.user.User;
 import com.github.llamara.ai.internal.internal.security.user.UserManager;
+import io.quarkus.logging.Log;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -69,8 +72,26 @@ public class UserKnowledgeManagerImpl implements UserKnowledgeManager {
 
     @Override
     public Collection<Knowledge> getAllKnowledge() {
+        String username = identity.getPrincipal().getName();
+
         userManager.enforceRegistered();
-        return userAwareRepository.listAll();
+        Set<Knowledge> publicKnowledge =
+                new HashSet<>(userAwareRepository.listAllPublicKnowledge());
+        if (identity.isAnonymous()) {
+            Log.debug("Anonymous user requested knowledge, returning only public knowledge.");
+            return publicKnowledge;
+        }
+        if (identity.hasRole(Roles.ADMIN)) {
+            Log.debugf("Admin user '%s' requested knowledge, returning all knowledge.", username);
+            return delegate.getAllKnowledge();
+        }
+        Log.debugf(
+                "Authenticated, non-admin user '%s' requested knowledge, returning user knowledge"
+                        + " and public knowledge.",
+                username);
+        Set<Knowledge> userKnowledge = new HashSet<>(userManager.getUser().getKnowledge());
+        userKnowledge.addAll(publicKnowledge);
+        return userKnowledge;
     }
 
     @Override

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/user/AnonymousUserManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/user/AnonymousUserManagerImpl.java
@@ -3,6 +3,8 @@ package com.github.llamara.ai.internal.internal.security.user;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 
+import com.github.llamara.ai.internal.internal.security.Users;
+
 /**
  * {@link UserManager} implementation for handling anonymous users.
  *
@@ -26,5 +28,10 @@ public class AnonymousUserManagerImpl implements UserManager {
     @Override
     public void delete() {
         // Do nothing here
+    }
+
+    @Override
+    public User getUser() {
+        return Users.ANY;
     }
 }

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/user/AuthenticatedUserManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/user/AuthenticatedUserManagerImpl.java
@@ -70,11 +70,7 @@ public class AuthenticatedUserManagerImpl implements UserManager {
 
     @Override
     public void delete() {
-        String username = identity.getPrincipal().getName();
-        User user = userRepository.findByUsername(username);
-        if (user == null) {
-            throw new UserNotRegisteredException(username);
-        }
+        User user = getUser();
         for (Session session : user.getSessions()) {
             try {
                 authenticatedUserSessionManager.deleteSession(session.getId());
@@ -91,5 +87,14 @@ public class AuthenticatedUserManagerImpl implements UserManager {
         userRepository.delete(user);
         QuarkusTransaction.commit();
         Log.debug(String.format("Deleted user '%s' from database.", user.getUsername()));
+    }
+
+    @Override
+    public User getUser() throws UserNotRegisteredException {
+        User user = userRepository.findByUsername(identity.getPrincipal().getName());
+        if (user == null) {
+            throw new UserNotRegisteredException(identity.getPrincipal().getName());
+        }
+        return user;
     }
 }

--- a/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserManager.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/security/user/UserManager.java
@@ -13,20 +13,32 @@ package com.github.llamara.ai.internal.internal.security.user;
  */
 public interface UserManager {
     /**
-     * Registers the user in, i.e. creates or updates the user in the database.
+     * Register current the user in, i.e. create or update the user in the database.
      *
      * @return {@code true} if the user was created, {@code false} if the user was updated
      */
     boolean register();
 
     /**
-     * Enforces that the user is registered. If the user is not registered, a {@link
+     * Enforce that the user is registered. If the user is not registered, a {@link
      * UserNotRegisteredException} is thrown.
      *
      * @throws UserNotRegisteredException if the user is not registered
      */
     void enforceRegistered() throws UserNotRegisteredException;
 
-    /** Deletes the current user and all his data. This includes removing all sessions. */
-    void delete();
+    /**
+     * Delets the current user and all his data. This includes removing all sessions.
+     *
+     * @throws UserNotRegisteredException if the user is not registered
+     */
+    void delete() throws UserNotRegisteredException;
+
+    /**
+     * Get the current user.
+     *
+     * @return the user
+     * @throws UserNotRegisteredException if the user is not registered
+     */
+    User getUser() throws UserNotRegisteredException;
 }

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/user/AnonymousUserManagerTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/user/AnonymousUserManagerTest.java
@@ -1,9 +1,11 @@
 package com.github.llamara.ai.internal.internal.security.user;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 
+import com.github.llamara.ai.internal.internal.security.Users;
 import com.github.llamara.ai.internal.internal.security.session.AnonymousUserSessionManagerImpl;
 import com.github.llamara.ai.internal.internal.security.session.SessionNotFoundException;
 import io.quarkus.test.InjectMock;
@@ -38,5 +40,10 @@ class AnonymousUserManagerTest {
     void deleteDoesNothing() throws SessionNotFoundException {
         userManager.delete();
         Mockito.verify(sessionManager, never()).deleteSession(Mockito.any());
+    }
+
+    @Test
+    void getUserReturnsUsersANY() {
+        assertEquals(Users.ANY, userManager.getUser());
     }
 }

--- a/src/test/java/com/github/llamara/ai/internal/internal/security/user/AuthenticatedUserManagerTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/internal/security/user/AuthenticatedUserManagerTest.java
@@ -69,6 +69,11 @@ class AuthenticatedUserManagerTest extends BaseForAuthenticatedUserTests {
         verify(sessionManager, never()).deleteSession(any());
     }
 
+    @Test
+    void getUserThrowsIfNotRegistered() {
+        assertThrows(UserNotRegisteredException.class, () -> userManager.getUser());
+    }
+
     @Nested
     class WithUser {
         @BeforeEach


### PR DESCRIPTION
- Add method to `User` entity to get all knowledge the user has explicit read permission to.
- Add method to `KnowledgeRepository` to get all public knowledge.
- Enforce that user is authenticated for knowledge modification operations in `UserKnowledgeManager` (this provides security independent from the REST resource `@RolesAllowed` annotation.)
- Use above get knowledge operations in `UserKnowledgeManager#getAllKnowledge`.