### PR TITLE
Check connection & initialize embedding store on startup

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/config/embedding/EmbeddingStoreConfig.java
+++ b/src/main/java/com/github/llamara/ai/internal/config/embedding/EmbeddingStoreConfig.java
@@ -32,6 +32,8 @@ public interface EmbeddingStoreConfig {
 
     String collectionName();
 
+    int vectorSize();
+
     String host();
 
     int port();

--- a/src/main/java/com/github/llamara/ai/internal/internal/knowledge/embedding/EmbeddingStorePermissionMetadataManager.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/knowledge/embedding/EmbeddingStorePermissionMetadataManager.java
@@ -20,6 +20,7 @@
 package com.github.llamara.ai.internal.internal.knowledge.embedding;
 
 import com.github.llamara.ai.internal.internal.MetadataKeys;
+import com.github.llamara.ai.internal.internal.StartupException;
 import com.github.llamara.ai.internal.internal.knowledge.Knowledge;
 import com.github.llamara.ai.internal.internal.security.PermissionMetadataMapper;
 
@@ -29,6 +30,18 @@ import com.github.llamara.ai.internal.internal.security.PermissionMetadataMapper
  * @author Florian Hotze - Initial contribution
  */
 public interface EmbeddingStorePermissionMetadataManager {
+    /**
+     * Check the connection to the configured {@link dev.langchain4j.store.embedding.EmbeddingStore}
+     * and initialize it if required. Throw a {@link StartupException} to abort application startup
+     * if no connection can be established or initialization fails.
+     *
+     * <p>MUST be called during application startup for the configured {@link
+     * dev.langchain4j.store.embedding.EmbeddingStore}.
+     *
+     * @throws StartupException if failed to connect or failed to initialize
+     */
+    void checkConnectionAndInit() throws StartupException;
+
     /**
      * Update the {@link MetadataKeys#PERMISSION} metadata of the embeddings of the given knowledge.
      *

--- a/src/main/java/com/github/llamara/ai/internal/internal/knowledge/embedding/EmbeddingStorePermissionMetadataManagerProducer.java
+++ b/src/main/java/com/github/llamara/ai/internal/internal/knowledge/embedding/EmbeddingStorePermissionMetadataManagerProducer.java
@@ -25,6 +25,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Produces;
 
 import com.github.llamara.ai.internal.config.embedding.EmbeddingStoreConfig;
+import io.quarkus.runtime.Startup;
 
 /**
  * CDI Bean Producer for {@link EmbeddingStorePermissionMetadataManager}. It produces the bean based
@@ -32,6 +33,7 @@ import com.github.llamara.ai.internal.config.embedding.EmbeddingStoreConfig;
  *
  * @author Florian Hotze - Initial contribution
  */
+@Startup // initialize at startup to check connection
 @ApplicationScoped
 class EmbeddingStorePermissionMetadataManagerProducer {
     private final EmbeddingStoreConfig config;
@@ -46,6 +48,8 @@ class EmbeddingStorePermissionMetadataManagerProducer {
         this.config = config;
         this.qdrantEmbeddingStorePermissionMetadataManager =
                 qdrantEmbeddingStorePermissionMetadataManager;
+
+        produceEmbeddingStorePermissionMetadataManager().checkConnectionAndInit();
     }
 
     @Produces

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,3 +1,10 @@
+embedding:
+  store:
+    type: qdrant # Supported types: qdrant
+    host: localhost
+    port: 6334 # Qdrant gRPC port
+    tls: false
+
 quarkus:
   keycloak:
     devservices:
@@ -34,3 +41,9 @@ quarkus:
       hosts: redis://localhost:6379/1
     chat-history:
       hosts: redis://localhost:6379/2
+
+  langchain4j:
+    qdrant:
+      devservices:
+        port: 6334
+        shared: false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,8 +23,10 @@ quarkus.test.profile=dev
 quarkus.langchain4j.memorystore.redis.client-name=chat-memory
 
 # Provide Qdrant host and collection name to make Quarkus happy (we provide our own configuration)
-quarkus.langchain4j.qdrant.host=null
-quarkus.langchain4j.qdrant.collection.name=null
+%prod.quarkus.langchain4j.qdrant.host=null
+%prod.quarkus.langchain4j.qdrant.collection.name=null
+%docker.quarkus.langchain4j.qdrant.host=null
+%docker.quarkus.langchain4j.qdrant.collection.name=null
 
 # Retrieve user information from OIDC provider
 quarkus.oidc.authentication.user-info-required=true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,7 @@ embedding:
     port: 6334 # Qdrant gRPC port
     tls: false
     collection-name: text-embedding-3-large
+    vector-size: 3072
   model:
     provider: openai # Supported providers: azure, openai, ollama
     # Azure OpenAI models need resource-name, model config and AZURE_API_KEY env variable


### PR DESCRIPTION
Abort application startup if no connection to the embedding store can be established.
Also enable Qdrant dev services as needed for the test environment.