### PR TITLE
Add Maven config for native image compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,5 @@ LLAMARA backend exposes four REST endpoints according to the [Eclipse Microprofi
 ## Known Issues
 
 - Filtering embeddings by permissions in the retrieval step only works if knowledge has only a single permission set.
+  The contains filter from <https://github.com/langchain4j/langchain4j/pull/2344> is needed to properly implement permissions in the retrieval step.
+- Native image does not work with Qdrant embedding store, see <https://github.com/quarkiverse/quarkus-langchain4j/issues/1216>.

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,7 @@
                             <goal>build</goal>
                             <goal>generate-code</goal>
                             <goal>generate-code-tests</goal>
+                            <goal>native-image-agent</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -257,6 +258,7 @@
                 <configuration>
                     <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>
@@ -334,4 +336,19 @@
                 </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>false</skipITs>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Native image currently does not work with Qdrant embedding store, see https://github.com/quarkiverse/quarkus-langchain4j/issues/1216.