### PR TITLE
Improve SonarQube CI action

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         java: [ '21' ]
         maven: [ '3.9.9' ]
-        sonar: [ '5.0.0.4389' ]
 
     runs-on: 'ubuntu-24.04'
 
@@ -43,4 +42,4 @@ jobs:
       - name: SonarQube Analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B --show-version --file pom.xml org.sonarsource.scanner.maven:sonar-maven-plugin:${{ matrix.sonar }}:sonar -Dsonar.projectKey=llamara-ai_llamara-backend
+        run: mvn -B --show-version --file pom.xml sonar:sonar -Dsonar.projectKey=llamara-ai_llamara-backend

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <!-- Configure SonarQube Cloud -->
         <sonar.organization>llamara-ai</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.coverage.jacoco.xmlReportPaths>target/jacoco-report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <licenses>
@@ -181,6 +182,15 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>5.0.0.4389</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Pin sonar maven plugin version through POM instead of action.
- Specify JaCoCo coverage path.