### PR TITLE
Change HTTP methods of non-idempotent REST endpoints from PUT to POST

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/rest/ChatResource.java
+++ b/src/main/java/com/github/llamara/ai/internal/rest/ChatResource.java
@@ -208,7 +208,7 @@ class ChatResource {
     }
 
     @Blocking
-    @PUT
+    @POST
     @Path("/sessions/create")
     @ResponseStatus(201)
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/github/llamara/ai/internal/rest/KnowledgeResource.java
+++ b/src/main/java/com/github/llamara/ai/internal/rest/KnowledgeResource.java
@@ -39,6 +39,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -174,7 +175,7 @@ class KnowledgeResource {
 
     @RolesAllowed({Roles.ADMIN, Roles.USER})
     @Blocking
-    @PUT
+    @POST
     @Path("/add/file")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
> The difference between PUT and POST is that PUT is idempotent: calling it once is no different from calling it several times successively (there are no side effects). Successive identical POST requests may have additional effects, such as creating the same order several times.

From https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST.