### PR TITLE
Fix wrong RAG sources provided if multiple sources from same knowledge

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/chat/response/RagSourceRecord.java
+++ b/src/main/java/com/github/llamara/ai/internal/chat/response/RagSourceRecord.java
@@ -25,7 +25,8 @@ import java.util.UUID;
  * Record for the source of a RAG response.
  *
  * @param knowledgeId the knowledge ID the source belongs to
+ * @param embeddingId the embedding ID of the source
  * @param content the content of the source
  * @author Florian Hotze - Initial contribution
  */
-public record RagSourceRecord(UUID knowledgeId, String content) {}
+public record RagSourceRecord(UUID knowledgeId, UUID embeddingId, String content) {}

--- a/src/main/java/com/github/llamara/ai/internal/retrieval/ContentInjectorImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/retrieval/ContentInjectorImpl.java
@@ -22,63 +22,199 @@ package com.github.llamara.ai.internal.retrieval;
 import com.github.llamara.ai.config.RetrievalConfig;
 import com.github.llamara.ai.internal.MetadataKeys;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static java.util.stream.Collectors.joining;
+
+import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.input.Prompt;
 import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.content.injector.ContentInjector;
-import dev.langchain4j.rag.content.injector.DefaultContentInjector;
 
 /**
  * Implementation of the {@link ContentInjector}. It injects the content based on the prompt
  * template from the {@link RetrievalConfig}. See <a
  * href="https://docs.langchain4j.dev/tutorials/rag/#content-injector">LangChain4j Docs: RAG:
- * Content Injector</a>.
+ * Content Injector</a>. <br>
+ * <br>
+ * Implementation is based on <a
+ * href="https://github.com/langchain4j/langchain4j/blob/f1a41b23818edac7af7bf34a17af19a654f1d67b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/DefaultContentInjector.java">
+ * <code>dev.langchain4j.rag.content.injector.DefaultContentInjector</code></a>.
  *
  * @author Florian Hotze - Initial contribution
  */
 @ApplicationScoped
-class ContentInjectorImpl implements ContentInjector {
-    private static final String USER_MESSAGE_TEMPLATE = "{{userMessage}}";
-
-    private final RetrievalConfig config;
-    private final ContentInjector delegate;
+public class ContentInjectorImpl implements ContentInjector {
+    private final PromptTemplate promptTemplate;
+    private final PromptTemplate noContentsPromptTemplate;
+    private final List<String> textSegmentMetadataToInclude;
+    private final List<ContentMetadata> contentMetadataToInclude;
 
     @Inject
     ContentInjectorImpl(RetrievalConfig config) {
-        this.config = config;
-        this.delegate =
-                DefaultContentInjector.builder()
-                        .metadataKeysToInclude(List.of(MetadataKeys.KNOWLEDGE_ID))
-                        .promptTemplate(PromptTemplate.from(config.promptTemplate()))
-                        .build();
+        this.promptTemplate = PromptTemplate.from(config.promptTemplate());
+        this.noContentsPromptTemplate =
+                PromptTemplate.from(config.missingKnowledgePromptTemplate());
+        this.textSegmentMetadataToInclude = List.of(MetadataKeys.KNOWLEDGE_ID);
+        this.contentMetadataToInclude = List.of(ContentMetadata.EMBEDDING_ID);
     }
 
     @Override
     public ChatMessage inject(List<Content> contents, ChatMessage chatMessage) {
-        if (contents.isEmpty() && chatMessage instanceof UserMessage userMessage) {
-            return new UserMessage(
-                    config.missingKnowledgePromptTemplate()
-                            .replace(USER_MESSAGE_TEMPLATE, userMessage.singleText()));
+        if (!(chatMessage instanceof UserMessage userMessage)) {
+            return chatMessage;
         }
 
-        return delegate.inject(contents, chatMessage);
+        Prompt prompt = createPrompt(userMessage, contents);
+        if (isNotNullOrBlank(userMessage.name())) {
+            return prompt.toUserMessage(userMessage.name());
+        }
+
+        return prompt.toUserMessage();
     }
 
+    /**
+     * @deprecated use {@link #inject(List, ChatMessage)} instead.
+     */
     @Override
+    @Deprecated
     public UserMessage inject(List<Content> contents, UserMessage userMessage) {
+        return (UserMessage) inject(contents, (ChatMessage) userMessage);
+    }
+
+    /**
+     * Combines the original {@link UserMessage} and the retrieved {@link Content}s into the
+     * resulting {@link UserMessage} based on the {@link PromptTemplate}s. <br>
+     * <br>
+     * It appends all given {@link Content}s to the end of the given {@link UserMessage} in their
+     * order of iteration. It optionally includes a list of {@link TextSegment} and {@link Content}
+     * metadata with each {@link Content} respective {@link Content#textSegment()}.
+     *
+     * @param userMessage
+     * @param contents
+     * @return
+     */
+    private Prompt createPrompt(UserMessage userMessage, List<Content> contents) {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("userMessage", userMessage.singleText());
+
         if (contents.isEmpty()) {
-            return new UserMessage(
-                    config.missingKnowledgePromptTemplate()
-                            .replace(USER_MESSAGE_TEMPLATE, userMessage.singleText()));
+            return noContentsPromptTemplate.apply(variables);
         }
 
-        return delegate
-                .inject( // NOSONAR: we need to use this method for implementation of interface
-                        contents, userMessage);
+        variables.put("contents", format(contents));
+        return promptTemplate.apply(variables);
+    }
+
+    /**
+     * Formats the given list of {@link Content}s in their order of iteration.
+     *
+     * @param contents
+     * @return
+     */
+    private String format(List<Content> contents) {
+        return contents.stream().map(this::format).collect(joining("\n\n"));
+    }
+
+    /**
+     * Formats the given {@link Content} and includes the specified {@link TextSegment} and {@link
+     * ContentMetadata} keys.
+     *
+     * @param content
+     * @return
+     */
+    private String format(Content content) {
+
+        TextSegment segment = content.textSegment();
+
+        if (isNullOrEmpty(textSegmentMetadataToInclude)
+                && isNullOrEmpty(contentMetadataToInclude)) {
+            return segment.text();
+        }
+
+        String segmentContent = segment.text();
+        String segmentMetadata = format(segment.metadata());
+        String contentMetadata = format(content.metadata());
+
+        return format(segmentContent, segmentMetadata, contentMetadata);
+    }
+
+    /**
+     * Formats the given metadata of a {@link TextSegment} and includes the specified {@link
+     * Metadata} keys.
+     *
+     * @param metadata
+     * @return
+     */
+    private String format(Metadata metadata) {
+        StringBuilder formattedMetadata = new StringBuilder();
+        for (String metadataKey : textSegmentMetadataToInclude) {
+            String metadataValue = metadata.getString(metadataKey);
+            if (metadataValue != null) {
+                if (!formattedMetadata.isEmpty()) {
+                    formattedMetadata.append("\n");
+                }
+                formattedMetadata.append(metadataKey).append(": ").append(metadataValue);
+            }
+        }
+        return formattedMetadata.toString();
+    }
+
+    /**
+     * Formats the given metadata of a {@link Content} and includes the specified {@link
+     * ContentMetadata} keys.
+     *
+     * @param metadata
+     * @return
+     */
+    private String format(Map<ContentMetadata, Object> metadata) {
+        StringBuilder formattedMetadata = new StringBuilder();
+        for (ContentMetadata metadataKey : contentMetadataToInclude) {
+            Object metadataValue = metadata.get(metadataKey);
+            if (metadataValue != null) {
+                if (!formattedMetadata.isEmpty()) {
+                    formattedMetadata.append("\n");
+                }
+                formattedMetadata
+                        .append(metadataKey.toString().toLowerCase())
+                        .append(": ")
+                        .append(metadataValue);
+            }
+        }
+        return formattedMetadata.toString();
+    }
+
+    /**
+     * Formats the given segment content, segment metadata, and content metadata strings.
+     *
+     * @param segmentContent
+     * @param segmentMetadata
+     * @param contentMetadata
+     * @return
+     */
+    private String format(String segmentContent, String segmentMetadata, String contentMetadata) {
+        if (segmentMetadata.isEmpty()) {
+            return contentMetadata.isEmpty()
+                    ? segmentContent
+                    : String.format("content: %s%n%s", segmentContent, contentMetadata);
+        }
+
+        if (contentMetadata.isEmpty()) {
+            return String.format("content: %s%n%s", segmentContent, segmentMetadata);
+        }
+
+        return String.format(
+                "content: %s%n%s%n%s", segmentContent, segmentMetadata, contentMetadata);
     }
 }

--- a/src/main/java/com/github/llamara/ai/internal/retrieval/ContentInjectorImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/retrieval/ContentInjectorImpl.java
@@ -55,7 +55,7 @@ import dev.langchain4j.rag.content.injector.ContentInjector;
  * @author Florian Hotze - Initial contribution
  */
 @ApplicationScoped
-public class ContentInjectorImpl implements ContentInjector {
+class ContentInjectorImpl implements ContentInjector {
     private final PromptTemplate promptTemplate;
     private final PromptTemplate noContentsPromptTemplate;
     private final List<String> textSegmentMetadataToInclude;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -92,7 +92,7 @@ retrieval:
     
     Answer preferably using the following information.
     When answering using the following information, ALWAYS provide the source of the information for EACH paragraph.
-    The source is specified by the knowledge_id and MUST be in the following JSON format: { "knowledge_id": knowledge_id }.
+    The source is specified by the knowledge_id and embedding_id and MUST be in the following JSON format: { "knowledge_id": knowledge_id, "embedding_id": embedding_id }.
     Again: ALWAYS provide the source of the information for EACH paragraph.
     
     If, I repeat ONLY if explicitly asked for citation, cite the relevant parts word-by-word and provide the source of the information.


### PR DESCRIPTION
When multiple sources are from the same knowledge, the sources returned by the API and stored in history could not be assigned correctly to their usage.
This was, because the shown sources were only identified by their knowledge ID, which was not unique to each single source.
This is fixed by using the embedding ID, which is unique for each source, for filtering.