### PR TITLE
Produce EmbeddingModel & EmbeddingStore beans on startup

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/EmbeddingModelProducer.java
+++ b/src/main/java/com/github/llamara/ai/internal/EmbeddingModelProducer.java
@@ -42,7 +42,6 @@ import io.quarkus.runtime.Startup;
  *
  * @author Florian Hotze - Initial contribution
  */
-@Startup // initialize at startup to validate config
 @ApplicationScoped
 class EmbeddingModelProducer {
     private final EmbeddingModelConfig config;
@@ -52,10 +51,9 @@ class EmbeddingModelProducer {
     EmbeddingModelProducer(EmbeddingModelConfig config, EnvironmentVariables env) {
         this.config = config;
         this.env = env;
-
-        produceEmbeddingModel();
     }
 
+    @Startup // create bean at startup to validate config
     @Produces
     @ApplicationScoped
     EmbeddingModel produceEmbeddingModel() {

--- a/src/main/java/com/github/llamara/ai/internal/EmbeddingStoreProducer.java
+++ b/src/main/java/com/github/llamara/ai/internal/EmbeddingStoreProducer.java
@@ -30,6 +30,7 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
 import io.quarkus.logging.Log;
+import io.quarkus.runtime.Startup;
 
 /**
  * CDI Bean Producer for {@link EmbeddingStore}. It produces the bean based on the {@link
@@ -48,6 +49,7 @@ class EmbeddingStoreProducer {
         this.env = env;
     }
 
+    @Startup // create bean at startup to validate config
     @Produces
     @ApplicationScoped
     EmbeddingStore<TextSegment> produceEmbeddingStore() {

--- a/src/main/java/com/github/llamara/ai/internal/knowledge/embedding/EmbeddingStorePermissionMetadataManagerProducer.java
+++ b/src/main/java/com/github/llamara/ai/internal/knowledge/embedding/EmbeddingStorePermissionMetadataManagerProducer.java
@@ -34,7 +34,6 @@ import io.quarkus.runtime.Startup;
  *
  * @author Florian Hotze - Initial contribution
  */
-@Startup // initialize at startup to check connection
 @ApplicationScoped
 class EmbeddingStorePermissionMetadataManagerProducer {
     private final EmbeddingStoreConfig config;
@@ -49,10 +48,9 @@ class EmbeddingStorePermissionMetadataManagerProducer {
         this.config = config;
         this.qdrantEmbeddingStorePermissionMetadataManager =
                 qdrantEmbeddingStorePermissionMetadataManager;
-
-        produceEmbeddingStorePermissionMetadataManager().checkConnectionAndInit();
     }
 
+    @Startup // create bean at startup to check connection
     @Produces
     @Default
     @ApplicationScoped

--- a/src/main/java/com/github/llamara/ai/internal/knowledge/embedding/QdrantEmbeddingStorePermissionMetadataManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/knowledge/embedding/QdrantEmbeddingStorePermissionMetadataManagerImpl.java
@@ -41,6 +41,7 @@ import io.qdrant.client.QdrantGrpcClient;
 import io.qdrant.client.grpc.Collections;
 import io.qdrant.client.grpc.Points;
 import io.quarkus.logging.Log;
+import io.quarkus.runtime.Startup;
 
 /**
  * Implementation of {@link EmbeddingStorePermissionMetadataManager} for Qdrant.
@@ -70,6 +71,7 @@ class QdrantEmbeddingStorePermissionMetadataManagerImpl
         this.collectionName = config.collectionName();
     }
 
+    @Startup
     @Override
     public void checkConnectionAndInit() {
         boolean collectionExists;


### PR DESCRIPTION
- Allows to validate config during startup.
- Avoid delay due to bean production when processing first request.