### PR TITLE
Support local file system as FileStorage alternative to MinIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ as well as possibly serving research findings in an accessible way to the public
   - [Ollama](https://ollama.com/)
 - Integration with the following embedding stores:
   - [Qdrant](https://qdrant.tech/)
+- Store the uploaded files in the following file storages:
+  - [MinIO](https://min.io/)
+  - Local File System
 - Build with [Quarkus](https://quarkus.io/), the Supersonic Subatomic Java Framework
 - Uses [LangChain4j](https://docs.langchain4j.dev/), the versatile LLM integration library
 - Relies on battle-tested open-source software such as [PostgreSQL](https://www.postgresql.org/), [MinIO](https://min.io/) & [Redis](https://redis.io/)
@@ -81,8 +84,8 @@ The application requires its tables to be available in the configured JDBC datab
 
 #### MinIO
 
-The application requires a [MinIO](https://min.io) object storage on `localhost:9000` (default).
-You need to set up access and secret key through the MinIO web interface and provide them through the `QUARKUS_MINIO_ACCESS_KEY` and `QUARKUS_MINIO_SECRET_KEY` environment variables.
+The application requires a [MinIO](https://min.io) object storage on `http://localhost:9000` (default).
+You need to set up access and secret key through the MinIO web interface and provide them through the `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` environment variables.
 
 #### Redis
 

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -106,12 +106,16 @@ COPY --chown=185 target/quarkus-app/*.jar /deployments/
 COPY --chown=185 target/quarkus-app/app/ /deployments/app/
 COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
+USER root
+RUN mkdir /data && chown 185 /data
+
 EXPOSE 8080
 USER 185
 ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus.profile=docker -Dquarkus.config.locations=file:/config/application.yaml"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 VOLUME /config
+VOLUME /data
 
 ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
 

--- a/src/main/java/com/github/llamara/ai/config/EnvironmentVariables.java
+++ b/src/main/java/com/github/llamara/ai/config/EnvironmentVariables.java
@@ -35,15 +35,21 @@ public class EnvironmentVariables {
     private final Optional<String> azureApiKey;
     private final Optional<String> openaiApiKey;
     private final Optional<String> qdrantApiKey;
+    private final Optional<String> minioAccessKey;
+    private final Optional<String> minioSecretKey;
 
     @Inject
     EnvironmentVariables(
             @ConfigProperty(name = "AZURE_API_KEY") Optional<String> azureApiKey,
             @ConfigProperty(name = "OPENAI_API_KEY") Optional<String> openaiApiKey,
-            @ConfigProperty(name = "QDRANT_API_KEY") Optional<String> qdrantApiKey) {
+            @ConfigProperty(name = "QDRANT_API_KEY") Optional<String> qdrantApiKey,
+            @ConfigProperty(name = "MINIO_ACCESS_KEY") Optional<String> minioAccessKey,
+            @ConfigProperty(name = "MINIO_SECRET_KEY") Optional<String> minioSecretKey) {
         this.azureApiKey = azureApiKey;
         this.openaiApiKey = openaiApiKey;
         this.qdrantApiKey = qdrantApiKey;
+        this.minioAccessKey = minioAccessKey;
+        this.minioSecretKey = minioSecretKey;
     }
 
     /**
@@ -77,5 +83,29 @@ public class EnvironmentVariables {
      */
     public Optional<String> getQdrantApiKey() {
         return qdrantApiKey;
+    }
+
+    /**
+     * Returns the MinIO access key.
+     *
+     * @return MinIO access key
+     */
+    public String getMinioAccessKey() {
+        if (minioAccessKey.isPresent()) {
+            return minioAccessKey.get();
+        }
+        throw new MissingEnvironmentVariableException("MinIO access key is required but missing.");
+    }
+
+    /**
+     * Returns the MinIO secret key.
+     *
+     * @return MinIO secret key
+     */
+    public String getMinioSecretKey() {
+        if (minioSecretKey.isPresent()) {
+            return minioSecretKey.get();
+        }
+        throw new MissingEnvironmentVariableException("MinIO secret key is required but missing.");
     }
 }

--- a/src/main/java/com/github/llamara/ai/config/FileStorageConfig.java
+++ b/src/main/java/com/github/llamara/ai/config/FileStorageConfig.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * llamara-backend
+ * %%
+ * Copyright (C) 2024 - 2025 Contributors to the LLAMARA project
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.github.llamara.ai.config;
+
+import java.util.Optional;
+
+import io.smallrye.config.ConfigMapping;
+
+/**
+ * Provides configuration for the {@link
+ * com.github.llamara.ai.internal.knowledge.storage.FileStorage} implementation.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@ConfigMapping(prefix = "file-storage")
+public interface FileStorageConfig {
+    FileStorageType type();
+
+    Optional<String> url();
+
+    Optional<Integer> port();
+
+    String bucketName();
+
+    boolean secure();
+
+    Optional<String> path();
+
+    enum FileStorageType {
+        FS,
+        MINIO
+    }
+}

--- a/src/main/java/com/github/llamara/ai/internal/knowledge/storage/FSFileStorageImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/knowledge/storage/FSFileStorageImpl.java
@@ -1,0 +1,115 @@
+/*
+ * #%L
+ * llamara-backend
+ * %%
+ * Copyright (C) 2024 - 2025 Contributors to the LLAMARA project
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.github.llamara.ai.internal.knowledge.storage;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.logging.Log;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.vertx.core.file.FileSystemException;
+
+/**
+ * Implementation of the {@link FileStorage} interface that stores files on the local file system.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+class FSFileStorageImpl implements FileStorage {
+    private final io.vertx.core.file.FileSystem fileSystem;
+    private final io.vertx.mutiny.core.file.FileSystem reactiveFileSystem;
+    private final String storagePath;
+
+    FSFileStorageImpl(
+            String storagePath,
+            io.vertx.core.Vertx vertx,
+            io.vertx.mutiny.core.Vertx reactiveVertx) {
+        this.fileSystem = vertx.fileSystem();
+        this.reactiveFileSystem = reactiveVertx.fileSystem();
+        this.storagePath = storagePath;
+
+        if (!fileSystem.existsBlocking(storagePath)) {
+            Log.infof("Creating storage directory '%s' ...", storagePath);
+            fileSystem.mkdirsBlocking(storagePath);
+        }
+    }
+
+    @Override
+    public void storeFile(String checksum, Path file, Map<String, String> metadata)
+            throws UnexpectedFileStorageFailureException {
+        try {
+            fileSystem.copyBlocking(file.toString(), Paths.get(storagePath, checksum).toString());
+        } catch (FileSystemException e) {
+            throw new UnexpectedFileStorageFailureException(
+                    String.format("Failed to store file with checksum '%s'", checksum), e);
+        }
+        Log.infof("Stored file '%s' with checksum '%s'.", file, checksum);
+    }
+
+    @Override
+    public FileContainer getFile(String checksum)
+            throws FileNotFoundException, UnexpectedFileStorageFailureException {
+        byte[] bytes;
+        try {
+            bytes =
+                    fileSystem
+                            .readFileBlocking(Paths.get(storagePath, checksum).toString())
+                            .getBytes();
+        } catch (FileSystemException e) {
+            if (e.getCause() instanceof NoSuchFileException) {
+                throw new FileNotFoundException(
+                        String.format("File not found for checksum '%s'", checksum));
+            }
+            throw new UnexpectedFileStorageFailureException(
+                    "Unexpected exception thrown while getting file", e);
+        }
+        InputStream content = new ByteArrayInputStream(bytes);
+        return new FileContainer(content, Collections.emptyMap());
+    }
+
+    @Override
+    public void deleteFile(String checksum) {
+        reactiveFileSystem
+                .delete(Paths.get(storagePath, checksum).toString())
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
+                .subscribe()
+                .with(
+                        item -> Log.infof("Deleted file with checksum '%s'.", checksum),
+                        failure -> {});
+    }
+
+    @Override
+    public void deleteAllFiles() {
+        reactiveFileSystem
+                .deleteRecursive(Paths.get(storagePath).toString(), true)
+                .onItem()
+                .transformToUni(uni -> reactiveFileSystem.mkdir(Paths.get(storagePath).toString()))
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
+                .subscribe()
+                .with(
+                        item -> Log.info("Deleted all files"),
+                        failure -> Log.errorf("Failed to delete all files: %s", failure));
+    }
+}

--- a/src/main/java/com/github/llamara/ai/internal/knowledge/storage/FileStorageProducer.java
+++ b/src/main/java/com/github/llamara/ai/internal/knowledge/storage/FileStorageProducer.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * llamara-backend
+ * %%
+ * Copyright (C) 2024 - 2025 Contributors to the LLAMARA project
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.github.llamara.ai.internal.knowledge.storage;
+
+import com.github.llamara.ai.config.EnvironmentVariables;
+import com.github.llamara.ai.config.FileStorageConfig;
+import com.github.llamara.ai.internal.StartupException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Produces;
+
+import io.minio.MinioClient;
+import io.minio.http.HttpUtils;
+import io.quarkus.runtime.Startup;
+
+/**
+ * CDI Bean Producer for {@link FileStorage}. It produces the bean based on the {@link
+ * FileStorageConfig}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@ApplicationScoped
+class FileStorageProducer {
+    private final FileStorageConfig config;
+    private final EnvironmentVariables env;
+    private final io.vertx.core.Vertx vertx;
+    private final io.vertx.mutiny.core.Vertx reactiveVertx;
+
+    @Inject
+    FileStorageProducer(
+            FileStorageConfig config,
+            EnvironmentVariables env,
+            io.vertx.core.Vertx vertx,
+            io.vertx.mutiny.core.Vertx reactiveVertx) {
+        this.config = config;
+        this.env = env;
+        this.vertx = vertx;
+        this.reactiveVertx = reactiveVertx;
+    }
+
+    @Startup // create bean at startup to check connection
+    @Produces
+    @ApplicationScoped
+    FileStorage produceFileStorage() {
+        return switch (config.type()) {
+            case FS -> produceFSFileStorage();
+            case MINIO -> produceMinioFileStorage();
+        };
+    }
+
+    private FSFileStorageImpl produceFSFileStorage() {
+        if (config.path().isEmpty()) {
+            throw new StartupException("File storage path is required but missing.");
+        }
+        return new FSFileStorageImpl(
+                config.path().get(), vertx, reactiveVertx); // NOSONAR: we have checked for empty
+    }
+
+    private MinioFileStorageImpl produceMinioFileStorage() {
+        if (config.url().isEmpty()) {
+            throw new StartupException("MinIO URL is required but missing.");
+        }
+        String url = config.url().get(); // NOSONAR: we have checked for empty
+
+        MinioClient.Builder builder = MinioClient.builder();
+        config.port()
+                .ifPresentOrElse(
+                        port -> builder.endpoint(url, port, config.secure()),
+                        () ->
+                                builder.endpoint(
+                                        HttpUtils.getBaseUrl(url)
+                                                .newBuilder()
+                                                .scheme(config.secure() ? "https" : "http")
+                                                .build()));
+        builder.credentials(env.getMinioAccessKey(), env.getMinioSecretKey());
+        return new MinioFileStorageImpl(builder.build(), config.bucketName());
+    }
+}

--- a/src/main/java/com/github/llamara/ai/internal/knowledge/storage/MinioFileStorageImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/knowledge/storage/MinioFileStorageImpl.java
@@ -28,8 +28,6 @@ import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 
 import io.minio.BucketExistsArgs;
 import io.minio.GetObjectArgs;
@@ -48,8 +46,6 @@ import io.minio.errors.ServerException;
 import io.minio.errors.XmlParserException;
 import io.minio.messages.Item;
 import io.quarkus.logging.Log;
-import io.quarkus.runtime.Startup;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Implementation of the {@link FileStorage} using <a href="https://min.io/">MinIO</a> as the
@@ -57,8 +53,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  *
  * @author Florian Hotze - Initial contribution
  */
-@Startup // initialize at startup to check connection
-@ApplicationScoped
 class MinioFileStorageImpl implements FileStorage {
     private static final String S3_EXCEPTION_MESSAGE = "Unexpected exception in S3 service";
     private static final String S3_ERROR_RESPONSE_MESSAGE =
@@ -67,10 +61,7 @@ class MinioFileStorageImpl implements FileStorage {
     private final String bucketName;
     private final MinioClient minioClient;
 
-    @Inject
-    MinioFileStorageImpl(
-            MinioClient minioClient,
-            @ConfigProperty(name = "quarkus.minio.bucket-name") String bucketName) {
+    MinioFileStorageImpl(MinioClient minioClient, String bucketName) {
         this.minioClient = minioClient;
         this.bucketName = bucketName;
 
@@ -96,7 +87,7 @@ class MinioFileStorageImpl implements FileStorage {
                 | NoSuchAlgorithmException
                 | XmlParserException e) {
             throw new UnexpectedFileStorageFailureException(
-                    "Unexpected exception thrown while creating bucket if missing", e);
+                    "Unexpected exception thrown while creating missing bucket", e);
         } catch (InvalidResponseException | IOException | ServerException e) {
             throw new UnexpectedFileStorageFailureException(S3_EXCEPTION_MESSAGE, e);
         } catch (ErrorResponseException e) {
@@ -154,7 +145,7 @@ class MinioFileStorageImpl implements FileStorage {
                 | NoSuchAlgorithmException
                 | XmlParserException e) {
             throw new UnexpectedFileStorageFailureException(
-                    "Unexpected exception thrown while deleting file from bucket", e);
+                    "Unexpected exception thrown while getting file from bucket", e);
         } catch (InvalidResponseException | IOException | ServerException e) {
             throw new UnexpectedFileStorageFailureException(S3_EXCEPTION_MESSAGE, e);
         } catch (ErrorResponseException e) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -5,6 +5,14 @@ embedding:
     port: 6334 # Qdrant gRPC port
     tls: false
 
+file-storage:
+  type: minio
+  url: http://localhost
+  port: 9000
+
+MINIO_ACCESS_KEY: minioaccess
+MINIO_SECRET_KEY: miniosecret
+
 quarkus:
   keycloak:
     devservices:
@@ -30,6 +38,7 @@ quarkus:
   minio:
     devservices:
       enabled: true
+      port: 9000
       shared: false
     url:
 

--- a/src/main/resources/application-docker.yaml
+++ b/src/main/resources/application-docker.yaml
@@ -19,6 +19,8 @@ file-storage:
   type: minio
   url: http://minio
   port: 9000
+  # Make sure that UID 185 has write access to this path when mounting it as volume
+  path: /data/knowledge
 
 quarkus:
   # Configure JDBC datasource (https://quarkus.io/guides/datasource#datasource-reference)

--- a/src/main/resources/application-docker.yaml
+++ b/src/main/resources/application-docker.yaml
@@ -1,7 +1,7 @@
 # User needs to:
 #   - provide the quarkus:oidc configuration
 #   - provide the following environment variables:
-#       QUARKUS_DATASOURCE_PASSWORD, QUARKUS_MINIO_ACCESS_KEY, QUARKUS_MINIO_SECRET_KEY,
+#       QUARKUS_DATASOURCE_PASSWORD, MINIO_ACCESS_KEY, MINIO_SECRET_KEY,
 #       QUARKUS_REDIS_CHAT_MEMORY_PASSWORD, QUARKUS_REDIS_HISTORY_PASSWORD, QUARKUS_OIDC_CREDENTIALS_SECRET=${OIDC_CREDENTIALS_SECRET}
 #     and with default model config: OPENAI_API_KEY
 
@@ -15,6 +15,11 @@ embedding:
     collection-name: text-embedding-3-large
     vector-size: 3072
 
+file-storage:
+  type: minio
+  url: http://minio
+  port: 9000
+
 quarkus:
   # Configure JDBC datasource (https://quarkus.io/guides/datasource#datasource-reference)
   datasource:
@@ -26,13 +31,6 @@ quarkus:
   hibernate-orm:
     database:
       generation: validate
-
-  # Configure Minio client for file storage
-  # You need to provide QUARKUS_MINIO_ACCESS_KEY and QUARKUS_MINIO_SECRET_KEY environment variables
-  minio:
-    url: http://minio
-    port: 9000
-    secure: false
 
   # Configure Redis client for chat memory & history
   redis:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,3 +1,9 @@
+file-storage:
+  # You need to provide MINIO_ACCESS_KEY and MINIO_SECRET_KEY environment variables
+  type: minio
+  url: http://localhost
+  port: 9000
+
 quarkus:
   # Configure OIDC provider
   oidc:
@@ -14,13 +20,6 @@ quarkus:
   hibernate-orm:
     database:
       generation: validate
-
-  # Configure Minio client for file storage
-  # You need to provide QUARKUS_MINIO_ACCESS_KEY and QUARKUS_MINIO_SECRET_KEY environment variables
-  minio:
-    url: http://localhost
-    port: 9000
-    secure: false
 
   # Configure Redis client for chat memory & history
   redis:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -78,6 +78,13 @@ embedding:
     # Ollama models need base URL and model config
     model: text-embedding-3-large
 
+file-storage:
+  type: minio # Supported types: minio, fs
+  # MinIO needs url configuration and MINIO_ACCESS_KEY and MINIO_SECRET_KEY env variables
+  # FS needs path configuration
+  bucket-name: llamara # The MinIO bucket name
+  secure: false
+
 ingestion:
   document-splitter:
     type: paragraph # Supported types: line, paragraph, recursive
@@ -111,8 +118,3 @@ retrieval:
       
       Answer based on your own knowledge.
       You MUST state that you are answering based on your own knowledge.
-
-quarkus:
-  minio:
-    # The name of the MinIO bucket to use.
-    bucket-name: llamara

--- a/src/test/java/com/github/llamara/ai/internal/knowledge/storage/FSFileStorageImplTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/knowledge/storage/FSFileStorageImplTest.java
@@ -1,0 +1,155 @@
+/*
+ * #%L
+ * llamara-backend
+ * %%
+ * Copyright (C) 2024 - 2025 Contributors to the LLAMARA project
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.github.llamara.ai.internal.knowledge.storage;
+
+import com.github.llamara.ai.internal.Utils;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.UUID;
+import jakarta.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link FSFileStorageImpl}. */
+@QuarkusTest
+class FSFileStorageImplTest {
+    private static final Path FILE = Path.of("src/test/resources/llamara.txt");
+    private static final String FILE_CHECKSUM;
+
+    static {
+        try {
+            FILE_CHECKSUM = Utils.generateChecksum(FILE);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Inject io.vertx.core.Vertx vertx;
+    @Inject io.vertx.mutiny.core.Vertx reactiveVertx;
+
+    String storagePath;
+    FileStorage fileStorage;
+
+    @BeforeEach
+    void setup() {
+        storagePath = "test_" + UUID.randomUUID() + "_knowledge";
+        fileStorage = new FSFileStorageImpl(storagePath, vertx, reactiveVertx);
+    }
+
+    @AfterEach
+    void destroy() {
+        fileStorage = null;
+        if (vertx.fileSystem().existsBlocking(storagePath)) {
+            vertx.fileSystem().deleteRecursiveBlocking(storagePath, true);
+        }
+    }
+
+    @Test
+    void fileStorageCreatesStorageDirIfItDoesNotExist() {
+        assertTrue(vertx.fileSystem().existsBlocking(storagePath));
+    }
+
+    @Test
+    void storeFileStoresFile() {
+        assertDoesNotThrow(
+                () -> fileStorage.storeFile(FILE_CHECKSUM, FILE, Collections.emptyMap()));
+        assertTrue(
+                vertx.fileSystem().existsBlocking(Path.of(storagePath, FILE_CHECKSUM).toString()));
+    }
+
+    @Test
+    void storeFileThrowsExceptionIfFileDoesNotExist() {
+        assertThrows(
+                UnexpectedFileStorageFailureException.class,
+                () ->
+                        fileStorage.storeFile(
+                                FILE_CHECKSUM, Path.of("nonexistent"), Collections.emptyMap()));
+    }
+
+    @Test
+    void storeFileThrowsExceptionIfStorageDirHasBeenRemoved() {
+        // when
+        vertx.fileSystem().deleteRecursiveBlocking(storagePath, true);
+
+        // then
+        assertThrows(
+                UnexpectedFileStorageFailureException.class,
+                () -> fileStorage.storeFile(FILE_CHECKSUM, FILE, Collections.emptyMap()));
+    }
+
+    @Test
+    void getFileThrowsFileNotFoundExceptionIfFileDoesNotExist() {
+        assertThrows(FileNotFoundException.class, () -> fileStorage.getFile("nonexistent"));
+    }
+
+    @Test
+    void getFileReturnsFileContainer() throws UnexpectedFileStorageFailureException, IOException {
+        // setup
+        fileStorage.storeFile(FILE_CHECKSUM, FILE, Collections.emptyMap());
+
+        // when
+        FileContainer fileContainer = assertDoesNotThrow(() -> fileStorage.getFile(FILE_CHECKSUM));
+
+        // when
+        assertTrue(fileContainer.content().readAllBytes().length > 0);
+    }
+
+    @Test
+    void deleteFileDeletesFile()
+            throws UnexpectedFileStorageFailureException, InterruptedException {
+        // setup
+        fileStorage.storeFile(FILE_CHECKSUM, FILE, Collections.emptyMap());
+
+        // when
+        assertDoesNotThrow(() -> fileStorage.deleteFile(FILE_CHECKSUM));
+        Thread.sleep(500); // NOSONAR: give the async delete some time to complete
+
+        // then
+        assertFalse(
+                vertx.fileSystem().existsBlocking(Path.of(storagePath, FILE_CHECKSUM).toString()));
+    }
+
+    @Test
+    void deleteAllFilesDeletesAllFiles()
+            throws UnexpectedFileStorageFailureException, InterruptedException {
+        // setup
+        fileStorage.storeFile(FILE_CHECKSUM, FILE, Collections.emptyMap());
+
+        // when
+        assertDoesNotThrow(() -> fileStorage.deleteAllFiles());
+        Thread.sleep(500); // NOSONAR: give the async delete some time to complete
+
+        // then
+        assertTrue(vertx.fileSystem().existsBlocking(storagePath));
+        assertFalse(
+                vertx.fileSystem().existsBlocking(Path.of(storagePath, FILE_CHECKSUM).toString()));
+    }
+}


### PR DESCRIPTION
This adds a FileStorage implementation that uses the local file system instead of MinIO.
These changes are breaking because the config format changed from Quarkus default MinIO config to our own custom config, and the env variables for MinIO credentials have been renamed.