### PR TITLE
Use JWT `preferred_username` and `full_name` claims instead of UserInfo

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/security/JwtUserInfoClaimsSecurityIdentityAugmentor.java
+++ b/src/main/java/com/github/llamara/ai/internal/security/JwtUserInfoClaimsSecurityIdentityAugmentor.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * llamara-backend
+ * %%
+ * Copyright (C) 2024 - 2025 Contributors to the LLAMARA project
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.github.llamara.ai.internal.security;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.logging.Log;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.jwt.auth.principal.JWTCallerPrincipal;
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.jwt.Claims;
+
+/**
+ * Augments the {@link SecurityIdentity} with user information claims from the JWT access token.
+ * This allows to provide the username and full name through {@link Claims#preferred_username} and
+ * {@link Claims#full_name} without needing a dependency on the {@link io.quarkus.oidc.UserInfo}. It
+ * also uses {@link Claims#preferred_username} as principal if available.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@ApplicationScoped
+class JwtUserInfoClaimsSecurityIdentityAugmentor implements SecurityIdentityAugmentor {
+
+    @Override
+    public Uni<SecurityIdentity> augment(
+            final SecurityIdentity identity, final AuthenticationRequestContext context) {
+        if (!(identity.getPrincipal() instanceof JWTCallerPrincipal principal)) {
+            return Uni.createFrom().item(identity);
+        }
+
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+
+        if (principal.containsClaim(Claims.preferred_username.name())) {
+            String username = principal.getClaim(Claims.preferred_username.name());
+            Log.tracef(
+                    "Using preferred_username claim as principal for SecurityIdentity: %s",
+                    username);
+            builder.setPrincipal(() -> username);
+        }
+        if (principal.containsClaim(Claims.full_name.name())) {
+            builder.addAttribute(
+                    Claims.full_name.name(), principal.getClaim(Claims.full_name.name()));
+        }
+
+        return Uni.createFrom().item(builder.build());
+    }
+}

--- a/src/main/java/com/github/llamara/ai/internal/security/user/AnonymousUserManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/security/user/AnonymousUserManagerImpl.java
@@ -43,7 +43,7 @@ public class AnonymousUserManagerImpl implements UserManager {
     }
 
     @Override
-    public boolean register(String displayName) {
+    public boolean register() {
         return true;
     }
 

--- a/src/main/java/com/github/llamara/ai/internal/security/user/AuthenticatedUserManagerImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/security/user/AuthenticatedUserManagerImpl.java
@@ -37,6 +37,7 @@ import jakarta.inject.Inject;
 import io.quarkus.logging.Log;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.jwt.Claims;
 
 /**
  * {@link UserManager} implementation for handling authenticated users.
@@ -67,7 +68,7 @@ public class AuthenticatedUserManagerImpl implements UserManager {
     }
 
     @Override
-    public boolean register(String displayName) {
+    public boolean register() {
         boolean created = false;
         QuarkusTransaction.begin();
         User user = userRepository.findByUsername(identity.getPrincipal().getName());
@@ -78,7 +79,7 @@ public class AuthenticatedUserManagerImpl implements UserManager {
         } else {
             Log.debugf("User '%s' found in database, updating user.", user.getUsername());
         }
-        user.setDisplayName(displayName);
+        user.setDisplayName(identity.getAttribute(Claims.full_name.name()));
         userRepository.persist(user);
         QuarkusTransaction.commit();
         return created;

--- a/src/main/java/com/github/llamara/ai/internal/security/user/UserManager.java
+++ b/src/main/java/com/github/llamara/ai/internal/security/user/UserManager.java
@@ -21,8 +21,8 @@ package com.github.llamara.ai.internal.security.user;
 
 /**
  * Interface specifying the API for managing users. A user is identified by its {@link
- * io.quarkus.security.identity.SecurityIdentity} and {@link io.quarkus.oidc.UserInfo}.
- * Authentication itself is handled by the OIDC provider, e.g. Keycloak.
+ * io.quarkus.security.identity.SecurityIdentity}. Authentication itself is handled by the OIDC
+ * provider, e.g. Keycloak.
  *
  * <p>Users must register before any user-specific operation can be performed. If the user has not
  * registered and tries to perform an operation, the operation can fail with {@link
@@ -34,10 +34,9 @@ public interface UserManager {
     /**
      * Register current the user in, i.e. create or update the user in the database.
      *
-     * @param displayName the display name of the user
      * @return {@code true} if the user was created, {@code false} if the user was updated
      */
-    boolean register(String displayName);
+    boolean register();
 
     /**
      * Enforce that the user is registered. If the user is not registered, a {@link

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -124,9 +124,6 @@ retrieval:
 quarkus:
   oidc:
     authentication:
-      # Retrieve user information from the OIDC provider
-      # When using Auth0, disable this to avoid rate limiting. Instead, provide the user's name through the "user_info/name" claim.
-      user-info-required: true
-    # When using Auth0, you need to set the roles claim path, e.g. to "user_info/roles", and create an action flow to map the roles to the token.
+    # When using Auth0, you need to set the roles claim path, e.g. to "auth0/roles", and create an action flow to map the roles to the token.
     # roles:
-      # role-claim-path: '"user_info/roles"'
+      # role-claim-path: '"auth0/roles"'

--- a/src/test/java/com/github/llamara/ai/internal/security/BaseForAuthenticatedUserTests.java
+++ b/src/test/java/com/github/llamara/ai/internal/security/BaseForAuthenticatedUserTests.java
@@ -45,6 +45,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import org.eclipse.microprofile.jwt.Claims;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -76,7 +77,6 @@ public abstract class BaseForAuthenticatedUserTests {
     @InjectSpy protected UserAwareSessionRepository userAwareSessionRepository;
 
     @InjectMock protected SecurityIdentity identity;
-    @InjectMock protected UserInfo userInfo;
 
     @Transactional
     @BeforeEach
@@ -111,7 +111,7 @@ public abstract class BaseForAuthenticatedUserTests {
      */
     protected void setupIdentity(String username, String displayName) {
         when(identity.getPrincipal()).thenReturn(() -> username);
-        when(userInfo.getName()).thenReturn(displayName);
+        when(identity.getAttribute(Claims.full_name.name())).thenReturn(displayName);
     }
 
     /**
@@ -120,7 +120,7 @@ public abstract class BaseForAuthenticatedUserTests {
     @Transactional
     protected void setupUser() {
         String username = identity.getPrincipal().getName();
-        String displayName = userInfo.getName();
+        String displayName = identity.getAttribute(Claims.full_name.name());
 
         User user = new User(username);
         user.setDisplayName(displayName);

--- a/src/test/java/com/github/llamara/ai/internal/security/JWTUserInfoClaimsSecurityIdentityAugmentorTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/security/JWTUserInfoClaimsSecurityIdentityAugmentorTest.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * llamara-backend
+ * %%
+ * Copyright (C) 2024 - 2025 Contributors to the LLAMARA project
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.github.llamara.ai.internal.security;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import org.eclipse.microprofile.jwt.Claims;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link JwtUserInfoClaimsSecurityIdentityAugmentor}. */
+@QuarkusTest
+class JWTUserInfoClaimsSecurityIdentityAugmentorTest {
+    private static final Supplier<QuarkusSecurityIdentity.Builder> IDENTITY_BUILDER =
+            () -> QuarkusSecurityIdentity.builder().setAnonymous(false).addRole("user");
+
+    private JwtUserInfoClaimsSecurityIdentityAugmentor augmentor;
+
+    @BeforeEach
+    void setup() {
+        augmentor = new JwtUserInfoClaimsSecurityIdentityAugmentor();
+    }
+
+    @Test
+    void doesNothingIfNotJwtPrincipal() {
+        // given
+        SecurityIdentity identity = IDENTITY_BUILDER.get().setPrincipal(() -> "test").build();
+
+        // when
+        Uni<SecurityIdentity> uni = augmentor.augment(identity, null);
+
+        // then
+        UniAssertSubscriber<SecurityIdentity> subscriber =
+                uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+        SecurityIdentity result = subscriber.assertCompleted().getItem();
+        assertEquals(identity, result);
+    }
+
+    @Test
+    void usesPreferredUsernameClaimAsPrincipal() throws InvalidJwtException {
+        // given
+        String upn = "upn";
+        String sub = "sub";
+        String preferredUsername = "preferred_username";
+        SecurityIdentity identity =
+                IDENTITY_BUILDER
+                        .get()
+                        .setPrincipal(
+                                new DefaultJWTCallerPrincipal(
+                                        null,
+                                        JwtClaims.parse(
+                                                String.format(
+                                                        "{\"upn\":\"%s\",\"sub\":\"%s\",\"preferred_username\":\"%s\"}",
+                                                        upn, sub, preferredUsername))))
+                        .build();
+        assertEquals(upn, identity.getPrincipal().getName());
+
+        // when
+        Uni<SecurityIdentity> uni = augmentor.augment(identity, null);
+
+        // then
+        UniAssertSubscriber<SecurityIdentity> subscriber =
+                uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+        SecurityIdentity result = subscriber.assertCompleted().getItem();
+        assertEquals(preferredUsername, result.getPrincipal().getName());
+    }
+
+    @Test
+    void addsFullNameAsAttribute() throws InvalidJwtException {
+        // given
+        String fullName = "full_name";
+        SecurityIdentity identity =
+                IDENTITY_BUILDER
+                        .get()
+                        .setPrincipal(
+                                new DefaultJWTCallerPrincipal(
+                                        null,
+                                        JwtClaims.parse(
+                                                String.format("{\"full_name\":\"%s\"}", fullName))))
+                        .build();
+
+        // when
+        Uni<SecurityIdentity> uni = augmentor.augment(identity, null);
+
+        // then
+        UniAssertSubscriber<SecurityIdentity> subscriber =
+                uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+        SecurityIdentity result = subscriber.assertCompleted().getItem();
+        assertEquals(fullName, result.getAttribute(Claims.full_name.name()));
+    }
+}

--- a/src/test/java/com/github/llamara/ai/internal/security/user/AnonymousUserManagerTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/security/user/AnonymousUserManagerTest.java
@@ -57,7 +57,7 @@ class AnonymousUserManagerTest {
 
     @Test
     void registerAlwaysClaimsToHaveCreatedUser() {
-        assertTrue(userManager.register("Test"));
+        assertTrue(userManager.register());
     }
 
     @Test

--- a/src/test/java/com/github/llamara/ai/internal/security/user/AuthenticatedUserManagerTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/security/user/AuthenticatedUserManagerTest.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.when;
 
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.jwt.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -77,7 +78,7 @@ class AuthenticatedUserManagerTest extends BaseForAuthenticatedUserTests {
 
     @Test
     void registerCreatesUserIfNotExists() {
-        assertTrue(userManager.register(OWN_DISPLAYNAME));
+        assertTrue(userManager.register());
         verify(userRepository, times(1)).persist((User) any());
         User user = userRepository.findByUsername(OWN_USERNAME);
         assertEquals(OWN_USERNAME, user.getUsername());
@@ -128,9 +129,9 @@ class AuthenticatedUserManagerTest extends BaseForAuthenticatedUserTests {
         @Test
         void loginUpdatesUser() {
             String newDisplayName = "New Name";
-            when(userInfo.getName()).thenReturn(newDisplayName);
+            when(identity.getAttribute(Claims.full_name.name())).thenReturn(newDisplayName);
 
-            assertFalse(userManager.register(newDisplayName));
+            assertFalse(userManager.register());
             verify(userRepository, times(1)).persist((User) any());
             User user = userRepository.findByUsername(OWN_USERNAME);
             assertEquals(OWN_USERNAME, user.getUsername());


### PR DESCRIPTION
- Allows to get the user's full name without needing to access the user info API.
- Uses the preferred_username claim as SecurityIdentity Principal if available. Allows to use the Auth0 username instead of the technical Auth0 user ID for the username.