### PR TITLE
Use JWT `name` claim as fallback for `full_name` claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This application requires an OIDC authentication provider to be set up.
 The OIDC provider requires the `auth-server-url` and `client-id` to be set in the `application.yaml` file and the `QUARKUS_OIDC_CREDENTIALS_SECRET` environment variables.
 For Keycloak, you need to add the `microprofile-jwt` and `profile` scopes for the Quarkus client, see [Keycloak Server Documentation](https://www.keycloak.org/docs/latest/server_admin/#protocol).
 
-You need to add the `full_name` JWT claim to the access token in order to display the full name in the frontend.
+You need to add the `full_name` or `name` JWT claim to the access token in order to display the full name in the frontend.
 You can optionally add the `preferred_username` JWT claim to the access token in order to specify a username different from the technical user ID of some systems.
 
 ### AI Model Provider

--- a/src/main/java/com/github/llamara/ai/internal/security/JwtUserInfoClaimsSecurityIdentityAugmentor.java
+++ b/src/main/java/com/github/llamara/ai/internal/security/JwtUserInfoClaimsSecurityIdentityAugmentor.java
@@ -60,6 +60,8 @@ class JwtUserInfoClaimsSecurityIdentityAugmentor implements SecurityIdentityAugm
         if (principal.containsClaim(Claims.full_name.name())) {
             builder.addAttribute(
                     Claims.full_name.name(), principal.getClaim(Claims.full_name.name()));
+        } else if (principal.containsClaim("name")) {
+            builder.addAttribute(Claims.full_name.name(), principal.getClaim("name"));
         }
 
         return Uni.createFrom().item(builder.build());

--- a/src/test/java/com/github/llamara/ai/internal/security/JWTUserInfoClaimsSecurityIdentityAugmentorTest.java
+++ b/src/test/java/com/github/llamara/ai/internal/security/JWTUserInfoClaimsSecurityIdentityAugmentorTest.java
@@ -93,7 +93,7 @@ class JWTUserInfoClaimsSecurityIdentityAugmentorTest {
     }
 
     @Test
-    void addsFullNameAsAttribute() throws InvalidJwtException {
+    void addsFullNameClaimAsAttribute() throws InvalidJwtException {
         // given
         String fullName = "full_name";
         SecurityIdentity identity =
@@ -104,6 +104,30 @@ class JWTUserInfoClaimsSecurityIdentityAugmentorTest {
                                         null,
                                         JwtClaims.parse(
                                                 String.format("{\"full_name\":\"%s\"}", fullName))))
+                        .build();
+
+        // when
+        Uni<SecurityIdentity> uni = augmentor.augment(identity, null);
+
+        // then
+        UniAssertSubscriber<SecurityIdentity> subscriber =
+                uni.subscribe().withSubscriber(UniAssertSubscriber.create());
+        SecurityIdentity result = subscriber.assertCompleted().getItem();
+        assertEquals(fullName, result.getAttribute(Claims.full_name.name()));
+    }
+
+    @Test
+    void fallsBackToNameClaimForFullNameAttribute() throws InvalidJwtException {
+        // given
+        String fullName = "given_name";
+        SecurityIdentity identity =
+                IDENTITY_BUILDER
+                        .get()
+                        .setPrincipal(
+                                new DefaultJWTCallerPrincipal(
+                                        null,
+                                        JwtClaims.parse(
+                                                String.format("{\"name\":\"%s\"}", fullName))))
                         .build();
 
         // when


### PR DESCRIPTION
This allows to provide the full name from Keycloak.