### PR TITLE
Fix Ollama chat model usage: Specify HttpClientBuilder to use

### DIFF
--- a/src/main/java/com/github/llamara/ai/internal/chat/ChatModelProviderImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/chat/ChatModelProviderImpl.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import dev.langchain4j.http.client.jdk.JdkHttpClient;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.mistralai.MistralAiChatModel;
@@ -167,6 +168,7 @@ class ChatModelProviderImpl implements ChatModelProvider {
                                     "Base URL is required for Ollama chat model."));
                 }
                 yield OllamaChatModel.builder()
+                        .httpClientBuilder(JdkHttpClient.builder())
                         .baseUrl(config.baseUrl().get()) // NOSONAR: we have checked for empty
                         .modelName(config.model())
                         .temperature(config.temperature())


### PR DESCRIPTION
Fixes the following exception:

```
java.lang.IllegalStateException: Conflict: multiple HTTP clients have been found in the classpath: [dev.langchain4j.http.client.jdk.JdkHttpClientBuilderFactory, io.quarkiverse.langchain4j.jaxrsclient.JaxRsHttpClientBuilderFactory]. Please explicitly specify the one you wish to use.
         at dev.langchain4j.http.client.HttpClientBuilderLoader.loadHttpClientBuilder(HttpClientBuilderLoader.java:20)
         at dev.langchain4j.internal.Utils.getOrDefault(Utils.java:74)
         at dev.langchain4j.model.ollama.OllamaClient.<init>(OllamaClient.java:50)
         at dev.langchain4j.model.ollama.OllamaClient$Builder.build(OllamaClient.java:304)
         at dev.langchain4j.model.ollama.OllamaChatModel.<init>(OllamaChatModel.java:92)
         at dev.langchain4j.model.ollama.OllamaChatModel$OllamaChatModelBuilder.build(OllamaChatModel.java:334)
```