### PR TITLE
Improve GitHub Actions

### DIFF
--- a/.github/actions/maven-build/action.yaml
+++ b/.github/actions/maven-build/action.yaml
@@ -30,13 +30,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cache
+    - name: Set up Maven Cache
       uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
+          ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           ${{ runner.os }}-maven-
 
     - name: Set up Java
@@ -56,6 +57,8 @@ runs:
       env:
         OPENAI_API_KEY: ${{ inputs.OPENAI_API_KEY || 'sk-prod-key' }}
 
+    # this will identify modifications to files under source control during the workflow run;
+    # untracked files will be included as well!
     - name: Verify Changed Files
       if: ${{ inputs.skip_changed_files != 'true' }}
       id: verify-changed-files

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,9 @@ permissions:
 jobs:
   maven:
     name: Maven Build
-
     runs-on: "ubuntu-24.04"
+    # typical duration is ~2min, set a reasonable amount as limit (default is 6h)
+    timeout-minutes: 8
 
     steps:
       - name: Checkout repository
@@ -87,9 +88,10 @@ jobs:
           path: |
             target/jacoco-report
 
+      # pinning to SHA to mitigate possible supply chain attack
       - name: Trigger distro build
         if: github.repository == 'llamara-ai/llamara-backend' && github.event_name != 'pull_request' && github.ref_name == 'main'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.DISTRO_DISPATCH_BUILD_TOKEN }}
           repository: llamara-ai/llamara-distro
@@ -98,8 +100,9 @@ jobs:
   docker:
     name: Docker Build & Publish
     needs: maven
-
     runs-on: "ubuntu-24.04"
+    # typical duration is ~1min, set a reasonable amount as limit (default is 6h)
+    timeout-minutes: 4
 
     env:
       # Use docker.io for Docker Hub if empty
@@ -123,11 +126,12 @@ jobs:
 
       # Install the cosign tool
       # https://github.com/sigstore/cosign-installer
+      # pinning to SHA to mitigate possible supply chain attack
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
         with:
-          cosign-release: "v2.2.4"
+          cosign-release: "v2.4.3"
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    # typical duration is ~2.5min, set a reasonable amount as limit (default is 6h)
+    timeout-minutes: 10
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -11,8 +11,9 @@ on:
 jobs:
   build:
     name: Build & Analyze
-
     runs-on: "ubuntu-24.04"
+    # typical duration is ~2min, set a reasonable amount as limit (default is 6h)
+    timeout-minutes: 8
 
     steps:
       - name: Checkout repository
@@ -25,7 +26,9 @@ jobs:
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-sonar-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-sonar-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-sonar-
 
       - name: Maven Build
         uses: ./.github/actions/maven-build


### PR DESCRIPTION
- Cache devcontainers used by unit tests.
- Set job timeouts.
- Pin version of peter-evans/repository-dispatch action to SHA.
- Pin version of sigstore/cosign-installer action to SHA.
- Improve SonarQube cache.