### PR TITLE
Upgrade quarkus-langchain4j to 0.27.0.CR1 & langchain4j to 1.0.0-beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
     <quarkus.platform.version>3.21.4</quarkus.platform.version>
     <quarkus-minio.version>3.8.1</quarkus-minio.version>
     <!-- remember to sync LangChain4j version when upgrading -->
-    <quarkus-langchain4j.version>0.26.2</quarkus-langchain4j.version>
-    <langchain4j.version>1.0.0-beta2</langchain4j.version>
+    <quarkus-langchain4j.version>0.27.0.CR1</quarkus-langchain4j.version>
+    <langchain4j.version>1.0.0-beta3</langchain4j.version>
     <skipITs>true</skipITs>
     <!-- Configure SonarQube Cloud -->
     <sonar-scanner.version>5.1.0.4751</sonar-scanner.version>

--- a/src/main/java/com/github/llamara/ai/internal/retrieval/ContentInjectorImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/retrieval/ContentInjectorImpl.java
@@ -85,15 +85,6 @@ class ContentInjectorImpl implements ContentInjector {
     }
 
     /**
-     * @deprecated use {@link #inject(List, ChatMessage)} instead.
-     */
-    @Override
-    @Deprecated
-    public UserMessage inject(List<Content> contents, UserMessage userMessage) {
-        return (UserMessage) inject(contents, (ChatMessage) userMessage);
-    }
-
-    /**
      * Combines the original {@link UserMessage} and the retrieved {@link Content}s into the
      * resulting {@link UserMessage} based on the {@link PromptTemplate}s. <br>
      * <br>

--- a/src/main/java/com/github/llamara/ai/internal/retrieval/RetrievalAugmentorImpl.java
+++ b/src/main/java/com/github/llamara/ai/internal/retrieval/RetrievalAugmentorImpl.java
@@ -28,7 +28,6 @@ import jakarta.inject.Inject;
 
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.AugmentationRequest;
@@ -37,7 +36,6 @@ import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.injector.ContentInjector;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
-import dev.langchain4j.rag.query.Metadata;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.filter.Filter;
 import io.quarkus.logging.Log;
@@ -102,12 +100,5 @@ class RetrievalAugmentorImpl implements RetrievalAugmentor {
     @Override
     public AugmentationResult augment(AugmentationRequest augmentationRequest) {
         return delegate.augment(augmentationRequest);
-    }
-
-    @Override
-    public UserMessage augment(UserMessage userMessage, Metadata metadata) {
-        return delegate
-                .augment( // NOSONAR: we need to use this method for implementation of interface
-                        userMessage, metadata);
     }
 }


### PR DESCRIPTION
- Upgrade quarkus-langchain4j from 0.26.2 to 0.27.0.CR1
- Upgrade langchain4j from 1.0.0-beta2 to 1.0.0-beta3

Changelogs:
- https://github.com/quarkiverse/quarkus-langchain4j/compare/0.26.2...0.27.0.CR1
- https://github.com/langchain4j/langchain4j/compare/1.0.0-beta2...1.0.0-beta3