### PR TITLE
Add missing Brotli4J libs for aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,14 @@
       <artifactId>quarkus-undertow</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-x86_64</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-aarch64</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest</artifactId>
     </dependency>


### PR DESCRIPTION
Fixes

```
java.lang.UnsatisfiedLinkError: Failed to find Brotli native library in classpath: /lib/linux-aarch64/libbrotli.so
```

on aarch64 platforms like M-series Macs.